### PR TITLE
feat: upgrade streamlit and add popover

### DIFF
--- a/slavv-streamlit/app.py
+++ b/slavv-streamlit/app.py
@@ -198,7 +198,12 @@ def show_processing_page():
     
     # Processing parameters
     st.markdown("<h3 class=\"section-header\">Processing Parameters</h3>", unsafe_allow_html=True)
-    
+    with st.popover("ℹ️ Parameter tips", width=300):
+        st.write(
+            "Use the tabs below to adjust microscopy, vessel size, processing, "
+            "and advanced options. Defaults are provided for typical datasets."
+        )
+
     # Create tabs for parameter categories
     tab1, tab2, tab3, tab4 = st.tabs(["🔬 Microscopy", "📏 Vessel Sizes", "⚙️ Processing", "🔬 Advanced"])
     

--- a/slavv-streamlit/requirements.txt
+++ b/slavv-streamlit/requirements.txt
@@ -1,4 +1,4 @@
-streamlit>=1.46.0
+streamlit>=1.48.1
 numpy>=2.1.0
 scipy>=1.16.0
 scikit-image>=0.25.0

--- a/slavv-streamlit/src/visualization.py
+++ b/slavv-streamlit/src/visualization.py
@@ -16,6 +16,8 @@ from typing import Dict, List, Tuple, Optional, Any
 import logging
 from pathlib import Path
 
+from .utils import calculate_path_length
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -775,7 +777,6 @@ class NetworkVisualizer:
         logger.info(f"CASX export complete: {output_path}")
         return output_path
 
-<<<<<<< HEAD
     def _export_mat(self, vertices: Dict[str, Any], edges: Dict[str, Any],
                     network: Dict[str, Any], parameters: Dict[str, Any],
                     output_path: str) -> str:
@@ -807,8 +808,4 @@ class NetworkVisualizer:
         savemat(output_path, data, do_compression=True)
         logger.info(f"MAT export complete: {output_path}")
         return output_path
-=======
-
-from .utils import calculate_path_length
->>>>>>> c6e597b (Fix syntax error, remove unused imports, and refactor path length calculation into a shared utility.)
 


### PR DESCRIPTION
## Summary
- require Streamlit 1.48.1 and integrate a new parameter tips popover in the processing page
- resolve merge artifact in visualization module and centralize path length import

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8d637945883278e64603791f95e0e