### PR TITLE
Add vessel direction estimation and adaptive edge tracing

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,10 +23,10 @@ This document outlines planned improvements and added features for the SLAVV2Pyt
     - [ ] Volume-exclusion logic parity (ordering, tie-breaking, distance metric)
   - [x] `extract_edges` parity with `get_edges_V300.m`
     - [x] Implement proper gradient-descent ridge following (use energy gradients)
-    - [ ] Step size per origin radius and adaptive stepping termination
+    - [x] Step size per origin radius and adaptive stepping termination
     - [ ] Terminal detection: near-vertex, energy rise, out-of-bounds, max steps
     - [x] Implement/restore `_find_terminal_vertex` or remove call if redundant with `_near_vertex`
-    - [ ] Avoid duplicate/self edges; limit `number_of_edges_per_vertex`
+    - [x] Avoid duplicate/self edges; limit `number_of_edges_per_vertex`
   - [ ] `construct_network` parity with `get_network_V190.m`
     - [ ] Adjacency construction and symmetric connectivity
     - [ ] Strand/connected component tracing and bifurcation detection
@@ -50,7 +50,7 @@ This document outlines planned improvements and added features for the SLAVV2Pyt
 - [ ] Add network cleaning steps (hairs/orphans/cycles) per MATLAB scripts
 - [ ] Add preprocessing parity (intensity normalization, band fixes) inspired by `pre_processing.m` and `fix_intensity_bands.m`
 - [ ] Implement chunked/tiling processing using `get_chunking_lattice_V190.m` honoring `max_voxels_per_node_energy`
-- [ ] Implement vessel direction estimation parity (`get_vessel_directions_V2/V3/V5.m`) for better initial edge directions
+- [x] Implement vessel direction estimation parity (`get_vessel_directions_V2/V3/V5.m`) for better initial edge directions
 - [ ] Add watershed-based edge alternative (`get_edges_by_watershed.m`) as a selectable method
 - [ ] Implement strand combining/sorting/mismatch fixes (`combine_strands.m`, `sort_network_V180.m`, `fix_strand_vertex_mismatch*.m`)
 

--- a/docs/MATLAB_TO_PYTHON_MAPPING.md
+++ b/docs/MATLAB_TO_PYTHON_MAPPING.md
@@ -11,7 +11,7 @@ This document maps key MATLAB SLAVV functions/scripts to their Python counterpar
 |---|---|---|---|
 | `get_energy_V202.m` | `slavv-streamlit/src/vectorization_core.py:calculate_energy_field` | Approximate | Multi-scale Hessian energy with min-projection implemented; PSF weighting and kernel details not fully matched to MATLAB.
 | `get_vertices_V200.m` | `slavv-streamlit/src/vectorization_core.py:extract_vertices` | Approximate | Local minima and volume exclusion implemented; structuring element geometry/tie-breaking may differ.
-| `get_edges_V300.m` | `slavv-streamlit/src/vectorization_core.py:extract_edges` | Approximate | Edge tracing works; gradient-descent ridge following/termination heuristics simplified.
+| `get_edges_V300.m` | `slavv-streamlit/src/vectorization_core.py:extract_edges` | Approximate | Edge tracing uses radius-scaled steps with energy-rise termination, deduplicates self/duplicate edges; gradient-descent heuristics simplified. |
 | `get_network_V190.m` | `slavv-streamlit/src/vectorization_core.py:construct_network` | Approximate | Builds adjacency/strands; cleaning/dedup and stable keying simplified.
 
 ### Helpers and Subroutines
@@ -20,7 +20,7 @@ This document maps key MATLAB SLAVV functions/scripts to their Python counterpar
 |---|---|---|---|
 | `energy_filter_V200.m`, `get_filter_kernel.m` | Integrated in `calculate_energy_field` | Approximate | Kernel construction simplified; PSF handling partially implemented.
 | `construct_structuring_element*.m` | Integrated in vertex extraction | Approximate | Structuring element approximated; anisotropy handling may differ.
-| `get_vessel_directions_V2/V3/V5.m` | (not present) | Omitted | Direction estimation planned for improved initial edge directions.
+| `get_vessel_directions_V2/V3/V5.m` | `slavv-streamlit/src/vectorization_core.py:_estimate_vessel_directions` | Approximate | Radius-aware local Hessian eigenvectors seed edges; falls back to uniform directions if ill-conditioned. |
 | `get_chunking_lattice_V190.m` | (not present) | Omitted | Planned tiling/chunking for large volumes.
 | `pre_processing.m`, `fix_intensity_bands.m` | (not present) | Omitted | Basic normalization only; full preprocessing parity planned.
 | `combine_strands.m` | Integrated in `construct_network` | Approximate | Strand combining simplified.


### PR DESCRIPTION
## Summary
- estimate vessel directions using local Hessian eigenvectors
- seed edge tracing with estimated directions
- document MATLAB mapping and update TODO
- refine direction estimation with radius-aware Hessian and robust fallbacks
- clean up imports and clarify vessel-direction helper
- adapt edge tracing to scale step size with vessel radius and halt when energy rises
- prevent self and duplicate edges while respecting per-vertex edge limits

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a90820aefc8327808dcc71c2370b98