### PR TITLE
ci: guard advisory MATLAB parity job on runner availability

### DIFF
--- a/.github/workflows/matlab-random-component-parity.yml
+++ b/.github/workflows/matlab-random-component-parity.yml
@@ -34,6 +34,12 @@ concurrency:
 jobs:
   random-component-parity:
     name: R2019a random component parity (advisory)
+    # Only enqueue when the self-hosted MATLAB R2019a runner is online. Without
+    # this guard the job queues indefinitely (no matching runner exists), leaving
+    # a perpetually pending check on every PR. Set the repo/environment variable
+    # MATLAB_RUNNER_ONLINE=true once the runner is registered to re-enable it;
+    # workflow_dispatch always runs so the runner owner can trigger it manually.
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.MATLAB_RUNNER_ONLINE == 'true' }}
     runs-on: [self-hosted, windows, matlab-r2019a]
     timeout-minutes: 10
     # Keep this advisory until the corpus has a confirmed green baseline; branch


### PR DESCRIPTION
## Summary
- The **MATLAB Random Component Parity (Advisory)** job targets a `[self-hosted, windows, matlab-r2019a]` runner. The repo currently has **zero self-hosted runners registered** (`gh api .../actions/runners` → `total_count: 0`), so the job queues indefinitely on every PR that touches parity/energy paths.
- On PR #103 this left the check **pending for 17h+** until the CI watcher hit a GitHub API network timeout. The blocking gates (Regression Gate, Code Quality & Tests) were green; only this advisory job hung.
- Guard the job so it **skips cleanly** unless the runner is available: `if: github.event_name == 'workflow_dispatch' || vars.MATLAB_RUNNER_ONLINE == 'true'`.

## Behavior after this change
- On PRs: the advisory job shows as **skipped** instead of perpetually pending (it is already `continue-on-error: true` and non-required, so this does not affect mergeability).
- Manual `workflow_dispatch` still runs, so the runner owner can trigger it on demand.
- To re-enable automatic PR runs, register the self-hosted runner and set repo/environment variable `MATLAB_RUNNER_ONLINE=true`.

## Test plan
- [ ] Confirm this PR's own checks do not leave a pending MATLAB advisory job (it should skip).
- [ ] After a runner is registered + `MATLAB_RUNNER_ONLINE=true`, confirm the job enqueues again on a parity-path PR.

## Summary by Sourcery

CI:
- Add an if-condition to the MATLAB random component parity job so it is skipped on PRs unless manually dispatched or a MATLAB runner availability variable is true, preventing indefinitely pending checks.