### PR TITLE
⚙️ Improve GitHub Actions: least privilege and reliability

### DIFF
--- a/.github/workflows/matlab-random-component-parity.yml
+++ b/.github/workflows/matlab-random-component-parity.yml
@@ -27,6 +27,9 @@ on:
       - "external/Vectorization-Public"
       - ".github/workflows/matlab-random-component-parity.yml"
 
+permissions:
+  contents: read
+
 concurrency:
   group: matlab-r2019a-random-component-parity
   cancel-in-progress: false

--- a/.github/workflows/regression-gate.yml
+++ b/.github/workflows/regression-gate.yml
@@ -6,10 +6,18 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: regression-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality:
     name: Code Quality & Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add read-only workflow permissions
- prevent duplicate regression runs with concurrency cancellation
- cap the regression job runtime at 30 minutes

MATLAB parity behavior, self-hosted runner gating, and advisory semantics are unchanged.

- [x] Existing CI workflows and pyproject configuration reviewed
- [x] No hardware or private-dataset requirements added

## Summary by Sourcery

Tighten GitHub Actions workflow security and improve reliability of regression and MATLAB parity CI runs.

CI:
- Restrict GitHub Actions workflows to read-only repository contents permissions.
- Add concurrency control to the regression gate workflow to cancel duplicate in-progress runs for the same ref.
- Set a 30-minute timeout on the regression gate quality job to cap CI runtime.
- Apply read-only contents permissions to the MATLAB random component parity workflow while keeping existing concurrency semantics.