### PR TITLE
feat(parity): double-junction divergence localization harness

### DIFF
--- a/docs/plans/2026-08-14-003-feat-double-junction-divergence-harness-plan.md
+++ b/docs/plans/2026-08-14-003-feat-double-junction-divergence-harness-plan.md
@@ -1,0 +1,368 @@
+---
+title: Double-Junction Strand Divergence Investigation Harness - Plan
+type: feat
+date: 2026-08-14
+topic: double-junction-divergence-harness
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+---
+
+# Double-Junction Strand Divergence Investigation Harness - Plan
+
+## Goal Capsule
+
+- **Objective:** Turn the reported `double_junction_32` strands break (MATLAB 1 vs Python 3) into a cheap, stage-aware investigation harness that localizes MATLAB↔Python mismatch (or measurement error) with live dual-run — without treating results as Phase 1 Certification or folding into ADR 0013.
+- **Product authority:** This plan owns toy-rung divergence localization only. Claim Run Roots, ONE TRUTH, and claimed-energy production fixes are out of scope.
+- **Open blockers:** None.
+
+---
+
+## Product Contract
+
+### Summary
+
+Build an investigation layer on top of the existing synthetic complexity ladder so an operator can re-run `double_junction_32` (and the current first-break rung after recount) under live MATLAB↔Python dual-run, compare stage surfaces in order, and get a durable localization report. The first cheap falsifier is correcting MATLAB strand counting in the ladder loader: on-disk mats already show three MATLAB strands, so the published 1-vs-3 figure is a measurement bug until proven otherwise after recount.
+
+### Problem Frame
+
+The ladder stopped at rung `double_junction_32` with `first_break_surface=strands` and counts MATLAB 1 / Python 3 while vertices and spatial edge pairs matched. That invites a Network-assembly story. Live artifacts contradict the MATLAB count: `strands2vertices` is a numeric `(3, 2)` endpoint matrix, and Python has three strands whose endpoints align after 0-based normalization. The ladder’s `load_matlab_artifacts` treats non-object arrays as `n_strands = 1`, so the stop predicate can fire on a harness bug. Operators need a stage-by-stage localization path that (1) fixes that measurement, (2) re-runs live dual-run, and (3) only then attributes any remaining mismatch to candidates, final edges, or network — without promoting toys to Certification.
+
+### Key Decisions
+
+- KD1. **Not Certification / not ONE TRUTH.** (session-settled: user-directed — chosen over treating ladder or localization outcomes as Phase 1 ship evidence.) Governs R8.
+- KD2. **Separate from ADR 0013 claimed-energy bake-at-finalize.** (session-settled: user-directed — chosen over folding this toy into the full-volume ranking residual work.) Governs R9.
+- KD3. **Investigation harness first; production algorithm fix deferred.** (session-settled: user-directed — chosen over find-and-fix Network/Selection in one plan.) Governs R1–R7.
+- KD4. **Localization requires live MATLAB dual-run.** (session-settled: user-directed — chosen over frozen MATLAB stage dumps for CI.) Governs R5, R7.
+
+### How This Work Fits Together
+
+<!-- ce-section: work-relationships -->
+
+This plan owns **toy-rung divergence localization** only. Surrounding areas below are the current understanding, not a committed roadmap.
+
+- Synthetic complexity ladder (`docs/plans/2026-08-14-002-feat-synthetic-complexity-ladder-plan.md`)
+  - **Provides** the dual-run runner, rung geometries, and strict verts→edges→strands stop
+  - **Is extended** by correct strand counting and optional localization report mode
+- Phase 1 / ONE TRUTH / Claim Run Roots
+  - **Outside** this plan’s identity
+- Claimed Trace Energy bake-at-finalize (ADR 0013)
+  - **Outside** this plan’s identity; full-volume residual remains a separate track
+- ADR 0012 Network endpoint-pair multisets / E5 MATLAB-edge Network isolation
+  - **May inform** localization compare surfaces after recount; not a Certification claim here
+
+### Actors
+
+- A1. Parity operator — runs live dual-run localization, reads stage verdicts, does not update ONE TRUTH.
+- A2. Implementer — lands counting fix, compare helpers, localization report, and MATLAB-gated tests.
+
+### Requirements
+
+**Localization behavior**
+
+- R1. The harness can target the known break rung `double_junction_32` (and, after recount, whatever rung is the current ladder first-break) under the same dual-run pattern as the complexity ladder.
+- R2. Localization compares stages in order: Vertex Set → Candidate Set (when both sides expose it) → final Edge Set → Network strands — same-class only (raw↔raw, final↔final).
+- R3. Strand compare must count MATLAB `strands2vertices` correctly for numeric `(N, 2)` endpoint matrices, object cells, and single-row forms — never treat a multi-row numeric matrix as one strand.
+- R4. After correct counting, strand localization also reports undirected endpoint-pair multisets (ADR 0012-style), not count alone.
+- R5. A localization run requires a live MATLAB dual-run for that rung (reuse/skip-matlab is allowed only as an explicit operator override for iterate-on-compare, not as the primary localization claim).
+- R6. Durable output names the first differing stage (or `measurement_fixed_match` / full match), counts per side, and the non-Certification banner.
+- R7. Cheap falsifiers exist as unit tests for counting/compare helpers plus at least one live-MATLAB gated localization test path that is not part of the default unit CI gate.
+
+**Non-claims and boundaries**
+
+- R8. Localization outcomes must state they are not Certification / not Phase 1 and must not update ONE TRUTH or claim-run roots.
+- R9. This work does not implement the ADR 0013 claimed-energy production fix or a Network-stage rewrite as the default response to a toy strand mismatch.
+
+### Key Flows
+
+- F1. Recount then re-localize
+  - **Trigger:** Operator starts localization on `double_junction_32` after the counting fix.
+  - **Actors:** A1
+  - **Steps:** Live dual-run → correct strand load → verts / candidates / edges / strands compares → emit localization report.
+  - **Outcome:** Either measurement-fixed match (ladder may advance), or a true first differing stage with evidence.
+  - **Covered by:** R1–R6, R8
+
+- F2. True post-recount strand mismatch
+  - **Trigger:** After correct counts, verts and final spatial edge pairs still match but strand endpoint multisets differ.
+  - **Actors:** A1
+  - **Steps:** Report Network as the first differing surface; optionally note E5-style isolation (MATLAB Edge Set → Python Network) as the next cheap falsifier without implementing a production Network rewrite.
+  - **Outcome:** Investigation points at network assembly / indexing, not selection — only if finals truly match.
+  - **Covered by:** R2, R4, R6, R9
+
+### Acceptance Examples
+
+- AE1. Numeric `(3, 2)` MATLAB strands count as 3
+  - **Covers:** R3
+  - **Given:** A MATLAB-side fixture with `strands2vertices` shape `(3, 2)`
+  - **When:** Strand count / normalize helpers run
+  - **Then:** MATLAB strand count is 3, not 1
+
+- AE2. Localization after recount on `double_junction_32`
+  - **Covers:** R1, R4–R6, R8
+  - **Given:** Live dual-run artifacts for that rung with correct strand loading
+  - **When:** Localization runs
+  - **Then:** Report either match / measurement-fixed match, or a named first differing stage; banner says not Certification
+
+- AE3. Same-class only
+  - **Covers:** R2
+  - **Given:** Python candidates and MATLAB finals both present
+  - **When:** Localization compares stages
+  - **Then:** It does not treat Python `candidates.pkl` vs MATLAB `edges_*.mat` as a discovery mismatch
+
+### Success Criteria
+
+- SC1. The published 1-vs-3 strand stop cannot recur from the numeric-matrix counting bug alone.
+- SC2. An operator can run live localization on `double_junction_32` and read a stage verdict without improvising probes.
+- SC3. Cold readers cannot mistake the report for Phase 1 Certification or ADR 0013 completion.
+
+### Scope Boundaries
+
+**In scope**
+
+- Correct MATLAB strand counting in the ladder (and shared helpers used by localization)
+- Stage-ordered localization report / mode on the ladder dual-run surface
+- Endpoint-pair multiset strand compare for toys
+- Unit tests for helpers; live-MATLAB gated localization test path
+- Working hypothesis and isolation guidance for post-recount residuals
+
+**Deferred for later**
+
+- Production Network rewrite or Selection ranking fix driven by this toy
+- Emitting durable MATLAB raw Candidate Sets from the ladder `.m` driver if SpecialOutput does not already
+- Extending localization to crop / canonical claim roots
+- Nightly CI job that always has MATLAB
+
+**Outside this product's identity**
+
+- Phase 1 / ONE TRUTH / Claim Run Root updates
+- ADR 0013 Claimed Trace Energy production bake-at-finalize
+- Treating approximate strand-count % as Network Certification
+
+### Dependencies / Assumptions
+
+- D1. Synthetic complexity ladder dual-run (`scripts/run_synthetic_complexity_ladder.py`, compare/report modules, rung geometries) remains the base surface.
+- D2. MATLAB Vectorization-Public and `MATLAB_EXE` / `resolve_matlab_exe` remain available for live localization.
+- AS1. On current `double_junction_32` experiment artifacts, MATLAB `(3, 2)` strands and Python three strands with matching endpoint pairs imply the historical 1-vs-3 stop is primarily a loader bug until a fresh live dual-run after the fix says otherwise.
+- AS2. Default CI continues to run unit/integration gates without requiring MATLAB; live localization tests are gated and optional for machines without MATLAB.
+
+### Outstanding Questions
+
+**Resolve Before Planning**
+
+- None (scoping call-out resolved: live MATLAB).
+
+**Deferred to implementation**
+
+- Q1. Exact CLI shape (`--localize` on the ladder script vs a thin sibling script) — prefer extending the ladder entrypoint; implementer may choose the thinner path if coupling stays low.
+- Q2. Whether tiny experiment’s MATLAB loader shares the same bug and should be patched in the same PR — yes if the same else-branch pattern exists; otherwise defer.
+
+### Sources / Research
+
+- Ladder: `scripts/run_synthetic_complexity_ladder.py` (`load_matlab_artifacts`), `slavv_python/analytics/parity/probes/synthetic_dual_run_compare.py`, `synthetic_ladder_report.py`, `slavv_python/utils/synthetic.py`
+- Correct strand semantics: `slavv_python/analytics/parity/proof/array_normalization.py` (`_normalize_matlab_strands`), `artifact_comparator.py` (`_strand_endpoint_pairs`)
+- Live artifact check (2026-08-14): `workspace/experiments/synthetic_complexity_ladder/double_junction_32/` — MATLAB `strands2vertices` `(3, 2)`; Python `checkpoint_network.pkl` length 3; endpoint pairs align after 0-based normalize
+- Hygiene / same-class: `docs/solutions/best-practices/parity-experiment-hygiene.md`, `docs/solutions/parity/raw-vs-final-candidate-compare.md`
+- Ladder product plan: `docs/plans/2026-08-14-002-feat-synthetic-complexity-ladder-plan.md`
+- Network isolation pattern: `docs/plans/2026-08-14-001-feat-testable-parity-experiments-plan.md` (E5), ADR 0012
+- External research: skipped — local dual-run and proof-path patterns are sufficient
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. **Treat harness strand counting as the first localization target.** On-disk MATLAB `(3, 2)` vs loader `n_strands=1` is verified; do not open a Network rewrite from the published 1-vs-3 figure. Governs R3, R6; aligns KD3.
+- KTD2. **Reuse proof-path strand normalization, do not invent a third counter.** Prefer calling existing `_normalize_matlab_strands` (or a thin public wrapper in the probes package) from ladder/localization loaders so toys and Certification loaders agree on MATLAB strand shape. Governs R3, R4.
+- KTD3. **Live MATLAB for localization claims; pure unit tests for helpers.** (session-settled: user-directed — chosen over frozen CI MATLAB dumps.) Mark live tests `parity` + `slow` with skip-if-no-MATLAB; keep them out of the default unit CI gate. Operator may use `--skip-matlab` / `--reuse-python` only for compare iteration, not as the localization claim of record. Governs R5, R7; KD4.
+- KTD4. **Stage order and same-class discipline.** Vertices → candidates (if both sides) → final edges → strands; never cross raw↔final. If candidates are missing on MATLAB under the current ladder `.m` export, mark that stage `unavailable` and continue — do not invent a discovery residual from Python candidates vs MATLAB finals. Governs R2, AE3.
+- KTD5. **Working hypothesis (planning-time, revisable after recount).** Likely class for the *reported* break: measurement (strand count). If recount yields full match, ladder advances and any later break is a new localization target. If recount still fails strand endpoint multisets while final spatial edge pairs match, prefer Network assembly / indexing next, then E5 isolation — not ADR 0013 by default on this toy. Governs R9; KD2.
+
+### Assumptions
+
+- A-plan1. Extending `scripts/run_synthetic_complexity_ladder.py` with a localization mode (or shared helpers imported by a thin sibling) is preferred over a greenfield package.
+- A-plan2. After the counting fix, a fresh live dual-run may show `double_junction_32` as a full match; that is a successful investigation outcome (`measurement_fixed_match`), not a failed harness.
+- A-plan3. Endpoint-pair multiset compare for toys uses the same undirected pair sense as ADR 0012 helpers, with explicit 0- vs 1-based handling already present in the ladder compare.
+
+### High-Level Technical Design
+
+Localization control flow (directional):
+
+```mermaid
+flowchart TD
+  start[Live dual-run rung] --> load[Load stage artifacts]
+  load --> countFix[Normalize MATLAB strands via proof-path helper]
+  countFix --> verts{Vertex spatial keys match?}
+  verts -->|no| stopV[first_diff vertices]
+  verts -->|yes| cand{Candidates both available?}
+  cand -->|yes unequal| stopC[first_diff candidates]
+  cand -->|missing or match| edges{Final spatial edge pairs match?}
+  edges -->|no| stopE[first_diff edges]
+  edges -->|yes| strands{Strand count and endpoint multiset match?}
+  strands -->|no| stopS[first_diff strands]
+  strands -->|yes| match[match or measurement_fixed_match]
+```
+
+Isolation guidance after a true strand multiset miss (directional):
+
+```text
+final Edge Set spatial pairs match?
+  yes → try MATLAB edges → Python Network (E5-style) before blaming discovery/selection
+  no  → selection/cleanup or edge-index issues first; do not start at Network rewrite
+```
+
+### Scope Boundaries (implementation)
+
+**Deferred to Follow-Up Work**
+
+- MATLAB ladder driver changes to always dump raw candidates
+- Tiny experiment full refactor onto shared compare (beyond shared strand count fix if needed)
+- Production Network / Selection patches
+
+---
+
+## Implementation Units
+
+### U1. Correct MATLAB strand counting in dual-run loaders
+
+**Goal:** Stop treating numeric `(N, 2)` `strands2vertices` as a single strand; align ladder (and tiny, if same pattern) with proof-path normalization.
+
+**Requirements:** R3, AE1; KTD1, KTD2
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `scripts/run_synthetic_complexity_ladder.py` (`load_matlab_artifacts`)
+- Modify: `slavv_python/analytics/parity/probes/synthetic_dual_run_compare.py` (or a small adjacent helper module) if counting should live in-package for tests
+- Optional modify: tiny dual-run loader under `workspace/experiments/tiny_synthetic_matlab_python_diff/` if it shares the else-branch bug
+- Test: `tests/unit/analytics/parity/test_synthetic_dual_run_compare.py` (or new focused unit file under the same package)
+
+**Approach:**
+1. Replace the object/list/else→1 counting branch with proof-path `_normalize_matlab_strands` (or equivalent row-count for `(N, 2)` plus cell handling).
+2. Expose a pure helper that unit tests can call without MATLAB.
+3. Keep ladder report non-Certification note unchanged.
+
+**Patterns to follow:** `slavv_python/analytics/parity/proof/array_normalization.py`; existing dual-run compare tests.
+
+**Execution note:** Characterization-first — add a failing unit case with a `(3, 2)` uint8 fixture mirroring the live mat before changing the loader.
+
+**Test scenarios:**
+- Covers AE1. Happy path: `(3, 2)` numeric matrix → count 3.
+- Edge: object-dtype cell of three endpoint rows → count 3.
+- Edge: single-row `(1, 2)` or squeezed length-2 vector → count 1.
+- Error: missing `strands2vertices` → strand count null / non-comparable, not silent 1.
+
+**Verification:** Unit tests green without MATLAB; loader no longer returns 1 for the known `(3, 2)` shape.
+
+### U2. Strand endpoint multiset + stage localization helpers
+
+**Goal:** Pure helpers that compare vertices, optional candidates, final edges, and strands (count + undirected endpoint pairs) and return the first differing stage.
+
+**Requirements:** R2, R4, R6, AE3; KTD4, KTD5
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `slavv_python/analytics/parity/probes/synthetic_dual_run_compare.py`
+- Optional create: `slavv_python/analytics/parity/probes/synthetic_stage_localize.py` if compare module would exceed clarity/size limits
+- Test: `tests/unit/analytics/parity/test_synthetic_dual_run_compare.py` and/or `tests/unit/analytics/parity/test_synthetic_stage_localize.py`
+
+**Approach:**
+1. Add endpoint-pair extraction for MATLAB Nx2 strands and Python vertex-chain strands (ends only), with index-base handling consistent with the ladder.
+2. Add `first_diff_stage` (name may vary) ordered vertices → candidates → edges → strands; mark missing candidate side as skip, not fail.
+3. Keep graded tiny residuals out of the stop predicate.
+
+**Patterns to follow:** Existing `first_break_surface`; `_strand_endpoint_pairs` in the artifact comparator (reuse or mirror semantics, avoid Certification API as the operator stop surface).
+
+**Test scenarios:**
+- Happy path: verts+edges match, strand counts equal but endpoint multisets differ → first diff `strands`.
+- Happy path: all stages match → no diff / match.
+- Edge: candidates unavailable on one side → stage skipped; edges still compared.
+- Covers AE3. Error/guard: comparing Python candidates to MATLAB finals is not offered as a discovery verdict.
+
+**Verification:** Pure unit coverage of stage order and multiset equality without MATLAB.
+
+### U3. Operator localization mode on the ladder dual-run
+
+**Goal:** One operator path that live dual-runs a named rung (default `double_junction_32`), writes a localization report under the experiment tree, and never updates ONE TRUTH.
+
+**Requirements:** R1, R5, R6, R8, AE2; KD1, KD4; KTD3, KTD5
+
+**Dependencies:** U1, U2
+
+**Files:**
+- Modify: `scripts/run_synthetic_complexity_ladder.py` (preferred) or create a thin `scripts/localize_synthetic_rung_divergence.py` that reuses ladder run/load helpers
+- Modify: `slavv_python/analytics/parity/probes/synthetic_ladder_report.py` only if shared report assembly helps
+- Test: unit tests for report assembly fields; live path covered in U4
+
+**Approach:**
+1. Add a localization entry (flag or sibling script) that runs one rung with live MATLAB by default.
+2. Emit JSON including `first_diff_stage`, per-stage comparable flags, strand counts, endpoint multiset overlap, and non-Certification `note`.
+3. On post-fix match for a rung that previously “broke” on strands, allow outcome `measurement_fixed_match` (or equivalent) so operators do not treat “no residual” as harness failure.
+4. Document that full ladder re-run after U1 may advance past rung 2.
+
+**Patterns to follow:** Existing `run_one_rung` / `assemble_ladder_report`; solution note tone from the ladder tooling note / plan R10.
+
+**Test scenarios:**
+- Happy path (unit): given mocked side dicts with corrected strand counts matching, report outcome is match / measurement_fixed_match and note is non-Certification.
+- Edge: MATLAB unavailable → inconclusive / skipped localization claim, not match.
+- Integration intent: covered by U4 live test.
+
+**Verification:** Operator can run localization on `double_junction_32` and get a durable report path under `workspace/experiments/synthetic_complexity_ladder/`.
+
+### U4. Live-MATLAB gated localization test
+
+**Goal:** A pytest path that requires live MATLAB dual-run to assert localization wiring on `double_junction_32` (or the documented smoke rung), without making default unit CI depend on MATLAB.
+
+**Requirements:** R5, R7, AE2; KTD3
+
+**Dependencies:** U1, U2, U3
+
+**Files:**
+- Create: `tests/parity/test_synthetic_rung_localization_live.py` (or under `tests/integration/` with `parity` + `slow` markers — prefer a path/markers combo excluded from default `unit` gate)
+- Test expectation: live dual-run when MATLAB present; skip when absent
+
+**Approach:**
+1. Mark `parity` and `slow`; skip if `resolve_matlab_exe()` finds nothing.
+2. Run localization for `double_junction_32` with live MATLAB (bounded soft time; fail or xfail clearly on timeout).
+3. Assert report schema, non-Certification note, and that MATLAB strand count is not spuriously 1 when the loaded mat is `(N, 2)` with N>1.
+4. Do not assert Phase 1 / ADR 0012 Certification bars.
+
+**Patterns to follow:** Ladder’s `resolve_matlab_exe` / inconclusive semantics; avoid hard-fail-only patterns that break machines without MATLAB when the test is collected under optional markers.
+
+**Execution note:** Smoke-first on machines with MATLAB; default CI remains unit helpers from U1/U2.
+
+**Test scenarios:**
+- Covers AE2. Integration: live dual-run produces comparable localization report with correct strand counting.
+- Edge: no MATLAB → skipped (not failed).
+- Guard: report note contains non-Certification language.
+
+**Verification:** On a MATLAB-equipped machine, live test passes or clearly fails on real dual-run issues; on CI without MATLAB, test skips and unit suite stays green.
+
+---
+
+## Verification Contract
+
+- Unit: counting + stage localization helpers (U1, U2) without MATLAB.
+- Operator: live localization on `double_junction_32` after U1–U3; inspect report outcome.
+- Optional: re-run full ladder once; if rung 2 matches, confirm later rungs run under existing soft-cap rules.
+- Do not run `prove-exact` or update ONE TRUTH as part of this verification.
+- Quality: targeted pytest for new/changed unit files; ruff on touched Python.
+
+## Definition of Done
+
+- [ ] U1–U4 complete with their test scenarios addressed
+- [ ] Numeric `(N, 2)` MATLAB strands cannot report count 1 for N>1
+- [ ] Localization report exists for a live `double_junction_32` run (or skip documented when MATLAB absent in CI)
+- [ ] Plan outcomes explicitly non-Certification; no ONE TRUTH / ADR 0013 production claim
+- [ ] Working hypothesis updated in the report or solution note after recount (measurement-fixed vs true stage)
+
+## Appendix
+
+### Research confidence notes
+
+- Independent repo research + on-disk mat/checkpoint verification established the loader bug; learnings research reinforced same-class compare and “do not Network-rewrite from strand count alone.”
+- Flow analysis (in-thread after researchers returned): critical gap closed by `measurement_fixed_match` and unavailable-candidate handling; live-MATLAB vs default CI tension closed by KTD3 markers/skip.
+- External research was not load-bearing.
+- Doc review: full multi-persona `ce-doc-review` was not dispatched as nested independent reviewers in this harness; coherence pass was in-thread only (not independent corroboration).

--- a/scripts/run_synthetic_complexity_ladder.py
+++ b/scripts/run_synthetic_complexity_ladder.py
@@ -6,6 +6,8 @@ Results are informative only — NOT Certification / NOT Phase 1.
 Usage (repo root):
   .\\.venv\\Scripts\\python.exe scripts\\run_synthetic_complexity_ladder.py
   .\\.venv\\Scripts\\python.exe scripts\\run_synthetic_complexity_ladder.py --rung y_junction_32
+  .\\.venv\\Scripts\\python.exe scripts\\run_synthetic_complexity_ladder.py --localize
+  .\\.venv\\Scripts\\python.exe scripts\\run_synthetic_complexity_ladder.py --localize --rung double_junction_32
   .\\.venv\\Scripts\\python.exe scripts\\run_synthetic_complexity_ladder.py --skip-matlab --reuse-python
 """
 
@@ -29,7 +31,10 @@ import scipy.io as sio
 import tifffile
 
 from slavv_python.analytics.parity.probes.synthetic_dual_run_compare import (
+    LOCALIZATION_NON_CERTIFICATION_NOTE,
+    count_matlab_strands2vertices,
     first_break_surface,
+    localize_stage_compare,
     strict_compare_summary,
 )
 from slavv_python.analytics.parity.probes.synthetic_ladder_report import (
@@ -51,6 +56,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 EXP_DIR = REPO_ROOT / "workspace" / "experiments" / "synthetic_complexity_ladder"
 MATLAB_DRIVER = Path(__file__).resolve().parent / "vectorize_ladder_rung.m"
 REPORT_PATH = EXP_DIR / "ladder_report.json"
+# Historical published stop before the strand-count loader fix (measurement bug).
+HISTORICAL_STRAND_BREAK_RUNG = "double_junction_32"
 
 SEED = 20260814
 BG_UINT16 = 40
@@ -210,6 +217,7 @@ def _load_python_artifacts(run_dir: Path) -> dict[str, Any]:
         "ok": True,
         "positions": positions,
         "connections": connections,
+        "strands": strands,
         "n_vertices": int(positions.reshape(-1, 3).shape[0]),
         "n_edges": int(connections.reshape(-1, 2).shape[0]),
         "n_strands": len(strands) if strands is not None else None,
@@ -252,6 +260,7 @@ def run_python_for_rung(rung_id: str, *, reuse: bool = False) -> dict[str, Any]:
             "ok": True,
             "positions": positions,
             "connections": connections,
+            "strands": strands,
             "n_vertices": int(positions.reshape(-1, 3).shape[0]),
             "n_edges": int(connections.reshape(-1, 2).shape[0]),
             "n_strands": len(strands) if strands is not None else None,
@@ -298,19 +307,19 @@ def load_matlab_artifacts(batch_dir: Path) -> dict[str, Any]:
     if network_mat is not None:
         n = sio.loadmat(str(network_mat), squeeze_me=True, struct_as_record=False)
         strands = n.get("strands2vertices")
-        if strands is None:
-            out["n_strands"] = None
-        elif isinstance(strands, np.ndarray) and strands.dtype == object:
-            out["n_strands"] = int(strands.size)
-        elif isinstance(strands, (list, tuple)):
-            out["n_strands"] = len(strands)
-        else:
-            out["n_strands"] = 1
+        out["strands2vertices"] = strands
+        out["n_strands"] = count_matlab_strands2vertices(strands)
     return out
 
 
 def _safe_side(d: dict[str, Any]) -> dict[str, Any]:
-    skip = {"positions", "connections", "candidate_connections"}
+    skip = {
+        "positions",
+        "connections",
+        "candidate_connections",
+        "strands",
+        "strands2vertices",
+    }
     return {k: v for k, v in d.items() if k not in skip}
 
 
@@ -445,6 +454,90 @@ def run_ladder(
     )
 
 
+def run_localize(
+    rung_id: str,
+    *,
+    skip_matlab: bool,
+    reuse_python: bool,
+) -> dict[str, Any]:
+    """Live dual-run one rung and emit a stage-localization report.
+
+    Primary localization claims require live MATLAB (skip_matlab=False). Reuse /
+    skip-matlab is allowed only for iterate-on-compare, not as the claim of record.
+    """
+    EXP_DIR.mkdir(parents=True, exist_ok=True)
+    if MATLAB_DRIVER.is_file():
+        shutil.copy2(MATLAB_DRIVER, EXP_DIR / MATLAB_DRIVER.name)
+
+    result = run_one_rung(rung_id, skip_matlab=skip_matlab, reuse_python=reuse_python)
+    matlab_art = {}
+    python_art = {}
+    # Re-load full artifact dicts (including strand payloads) for localization.
+    matlab_run = result.get("matlab_run") or {}
+    if matlab_run.get("ok") and matlab_run.get("batch_dir"):
+        matlab_art = load_matlab_artifacts(Path(matlab_run["batch_dir"]))
+    python_run_meta = result.get("python_run") or {}
+    run_dir = python_run_meta.get("run_dir")
+    if run_dir:
+        try:
+            python_art = _load_python_artifacts(Path(run_dir))
+        except Exception as exc:
+            python_art = {"ok": False, "error": repr(exc)}
+    # Prefer in-memory arts from the rung result when loaders already attached strands.
+    # run_one_rung strips arrays via _safe_side; reload from disk above.
+
+    claim_of_record = not skip_matlab
+    if not matlab_run.get("available", True) and not skip_matlab:
+        localization = {
+            "comparable": False,
+            "outcome": "inconclusive",
+            "reason": matlab_run.get("error", "MATLAB unavailable"),
+            "first_diff_stage": None,
+            "note": LOCALIZATION_NON_CERTIFICATION_NOTE,
+        }
+    elif not matlab_art.get("ok") or not python_art.get("ok"):
+        localization = {
+            "comparable": False,
+            "outcome": "inconclusive",
+            "reason": "one side failed or non-comparable",
+            "first_diff_stage": None,
+            "note": LOCALIZATION_NON_CERTIFICATION_NOTE,
+        }
+    else:
+        localization = localize_stage_compare(
+            matlab_art,
+            python_art,
+            previously_reported_strand_break=(rung_id == HISTORICAL_STRAND_BREAK_RUNG),
+        )
+
+    report = {
+        "created_utc": _utc_now(),
+        "mode": "localize",
+        "rung_id": rung_id,
+        "note": LOCALIZATION_NON_CERTIFICATION_NOTE,
+        "claim_of_record": claim_of_record,
+        "skip_matlab": skip_matlab,
+        "reuse_python": reuse_python,
+        "rung_status": result.get("status"),
+        "ladder_first_break_surface": result.get("first_break_surface"),
+        "localization": localization,
+        "matlab_artifacts": _safe_side(matlab_art),
+        "python_artifacts": _safe_side(python_art),
+        "matlab_wall_sec": result.get("matlab_wall_sec"),
+        "python_wall_sec": result.get("python_wall_sec"),
+        "working_hypothesis": (
+            "Historical 1-vs-3 strands stop was a loader measurement bug on numeric "
+            "(N,2) strands2vertices; after recount, outcome is match / "
+            "measurement_fixed_match or a true first_diff_stage."
+        ),
+    }
+    out_path = EXP_DIR / rung_id / "localization_report.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+    report["report_path"] = str(out_path)
+    return report
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -453,9 +546,20 @@ def main(argv: list[str] | None = None) -> int:
         help="Run only this named rung (smoke / single-step).",
     )
     parser.add_argument(
+        "--localize",
+        action="store_true",
+        help=(
+            "Stage-localize one rung (default double_junction_32) with live MATLAB "
+            "dual-run; writes localization_report.json under the rung dir."
+        ),
+    )
+    parser.add_argument(
         "--skip-matlab",
         action="store_true",
-        help="Reuse latest per-rung matlab_batches/batch_* instead of launching MATLAB.",
+        help=(
+            "Reuse latest per-rung matlab_batches/batch_* instead of launching MATLAB. "
+            "For localization, this is iterate-on-compare only — not the claim of record."
+        ),
     )
     parser.add_argument(
         "--reuse-python",
@@ -475,6 +579,29 @@ def main(argv: list[str] | None = None) -> int:
         help="Refuse starting a rung whose max dim exceeds this (default 64).",
     )
     args = parser.parse_args(argv)
+
+    if args.localize:
+        rung_id = args.rung or HISTORICAL_STRAND_BREAK_RUNG
+        print(f"[{_utc_now()}] Synthetic rung localization")
+        print(f"  note: {LOCALIZATION_NON_CERTIFICATION_NOTE}")
+        print(f"  rung: {rung_id}")
+        print(f"  claim_of_record: {not args.skip_matlab}")
+        print(f"  MATLAB: {resolve_matlab_exe()}")
+        report = run_localize(
+            rung_id,
+            skip_matlab=bool(args.skip_matlab),
+            reuse_python=bool(args.reuse_python),
+        )
+        loc = report.get("localization") or {}
+        print(f"\nOUTCOME: {loc.get('outcome')}")
+        print(f"  first_diff_stage={loc.get('first_diff_stage')}")
+        print(f"  matlab_strands={(loc.get('counts') or {}).get('matlab_strands')}")
+        print(f"  python_strands={(loc.get('counts') or {}).get('python_strands')}")
+        print(f"Report: {report.get('report_path')}")
+        ok_outcomes = {"match", "measurement_fixed_match", "first_diff"}
+        if loc.get("outcome") in ok_outcomes and loc.get("comparable"):
+            return 0
+        return 1
 
     rung_ids: tuple[str, ...] = (args.rung,) if args.rung else LADDER_RUNG_IDS
     print(f"[{_utc_now()}] Synthetic complexity ladder")

--- a/slavv_python/analytics/parity/probes/synthetic_dual_run_compare.py
+++ b/slavv_python/analytics/parity/probes/synthetic_dual_run_compare.py
@@ -3,17 +3,30 @@
 Mirrors quantization / 0- vs 1-based handling from the tiny dual-run experiment, but
 exposes a *strict* first-break surface (vertices → edges → strands) for ladder stop.
 Graded ``first_big_break`` labels from the tiny script are not used as the stop predicate.
+
+Also provides stage-localization helpers (vertices → candidates → edges → strands) for
+toy-rung divergence investigation. Outcomes are NOT Certification / NOT Phase 1.
 """
 
 from __future__ import annotations
 
-from collections.abc import Hashable
+from collections import Counter
+from collections.abc import Hashable, Sequence
 from dataclasses import asdict, dataclass
 from typing import Any, Literal, TypeVar, cast
 
 import numpy as np
 
+from slavv_python.analytics.parity.proof.array_normalization import (
+    _normalize_matlab_strands,
+)
+
 FirstBreakSurface = Literal["vertices", "edges", "strands"]
+LocalizeStage = Literal["vertices", "candidates", "edges", "strands"]
+LOCALIZATION_NON_CERTIFICATION_NOTE = (
+    "Synthetic rung localization - NOT Certification / NOT Phase 1. "
+    "Do not update ONE TRUTH or claim-run roots from this report."
+)
 
 
 @dataclass(frozen=True)
@@ -30,6 +43,67 @@ class PairStats:
 
 class NonComparableArtifactsError(ValueError):
     """Raised when artifact dicts lack fields required for a strict compare."""
+
+
+def count_matlab_strands2vertices(value: Any) -> int | None:
+    """Count MATLAB ``strands2vertices`` rows without treating Nx2 numeric as 1.
+
+    Aligns with proof-path ``_normalize_matlab_strands`` for numeric endpoint matrices.
+    Object cells / Python sequences use element count. Missing → None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray) and value.dtype == object:
+        return int(value.size)
+    if isinstance(value, (list, tuple)):
+        return len(value)
+    strands = _normalize_matlab_strands(value)
+    return len(strands)
+
+
+def _endpoint_pair_from_flat(flat: np.ndarray) -> tuple[int, int]:
+    if flat.size == 0:
+        return (-1, -1)
+    lo, hi = sorted((int(flat[0]), int(flat[-1])))
+    return (lo, hi)
+
+
+def strand_endpoint_pair_multiset(
+    strands: Any,
+    *,
+    indices_one_based: bool,
+) -> Counter[tuple[int, int]]:
+    """Undirected endpoint-pair multiset (ADR 0012 sense) from strand payloads.
+
+    MATLAB ``strands2vertices`` is typically an ``(N, 2)`` endpoint matrix (or object
+    cell of endpoint rows). Python network strands are vertex-index chains; only the
+    chain ends are used.
+    """
+    if strands is None:
+        return Counter()
+
+    pairs: list[tuple[int, int]] = []
+    if isinstance(strands, np.ndarray) and strands.dtype == object:
+        items: Sequence[Any] = list(strands.reshape(-1))
+    elif isinstance(strands, (list, tuple)):
+        items = list(strands)
+    else:
+        arr = np.asarray(strands)
+        if arr.size == 0:
+            return Counter()
+        # Numeric Nx2 (or length-2 vector) → one pair per row.
+        rows = np.atleast_2d(arr).reshape(-1, 2)
+        items = list(rows)
+
+    for item in items:
+        flat = np.asarray(item).ravel()
+        if indices_one_based and flat.size:
+            flat = flat.astype(np.int64, copy=True)
+            positive = flat > 0
+            flat[positive] -= 1
+            flat[~positive] = -1
+        pairs.append(_endpoint_pair_from_flat(np.asarray(flat, dtype=np.int64)))
+    return Counter(pairs)
 
 
 def undirected_pairs(connections: np.ndarray) -> set[tuple[int, int]]:
@@ -164,9 +238,195 @@ def first_break_surface(
     if m_spatial != p_spatial:
         return "edges"
 
-    if matlab.get("n_strands") != python.get("n_strands"):
+    m_n = matlab.get("n_strands")
+    p_n = python.get("n_strands")
+    if m_n != p_n:
         return "strands"
+
+    # When both sides expose strand payloads, also require endpoint-pair multisets.
+    m_raw = matlab.get("strands2vertices", matlab.get("strands"))
+    p_raw = python.get("strands")
+    if m_raw is not None and p_raw is not None:
+        m_pairs = strand_endpoint_pair_multiset(m_raw, indices_one_based=True)
+        p_pairs = strand_endpoint_pair_multiset(p_raw, indices_one_based=False)
+        if m_pairs != p_pairs:
+            return "strands"
     return None
+
+
+def _candidate_pair_set(side: dict[str, Any]) -> set[tuple[int, int]] | None:
+    """Return undirected candidate pairs when present; None if unavailable."""
+    raw = side.get("candidate_connections")
+    if raw is None:
+        return None
+    return undirected_pairs(np.asarray(raw, dtype=np.int64))
+
+
+def _ordered_stage_statuses(
+    first_diff: LocalizeStage | None,
+    *,
+    candidates_status: Literal["unavailable", "match", "mismatch"],
+) -> dict[str, str]:
+    order: tuple[LocalizeStage, ...] = ("vertices", "candidates", "edges", "strands")
+    out: dict[str, str] = {}
+    for name in order:
+        if name == "candidates":
+            out[name] = candidates_status
+            continue
+        if first_diff is None:
+            out[name] = "match"
+            continue
+        if name == first_diff:
+            out[name] = "mismatch"
+        elif order.index(name) < order.index(first_diff):
+            out[name] = "match"
+        else:
+            out[name] = "not_reached"
+    return out
+
+
+def first_diff_stage(
+    matlab: dict[str, Any],
+    python: dict[str, Any],
+    *,
+    matlab_positions_one_based: bool = True,
+    matlab_connections_one_based: bool = True,
+    python_positions_one_based: bool = False,
+) -> LocalizeStage | None:
+    """First differing stage: vertices → candidates (if both) → edges → strands.
+
+    Missing candidates on either side skips that stage (unavailable), never a
+    discovery residual from Python candidates vs MATLAB finals.
+    """
+    _require_side(matlab, "matlab")
+    _require_side(python, "python")
+
+    vertex_keys_m = set(
+        position_keys_one_based(
+            matlab["positions"], positions_are_one_based=matlab_positions_one_based
+        )
+    )
+    vertex_keys_p = set(
+        position_keys_one_based(
+            python["positions"], positions_are_one_based=python_positions_one_based
+        )
+    )
+    if vertex_keys_m != vertex_keys_p:
+        return "vertices"
+
+    cand_m = _candidate_pair_set(matlab)
+    cand_p = _candidate_pair_set(python)
+    if cand_m is not None and cand_p is not None and cand_m != cand_p:
+        return "candidates"
+
+    p_conn = np.asarray(python["connections"], dtype=np.int64)
+    py_conn_one_based = bool(p_conn.size) and int(p_conn.min()) >= 1
+    m_spatial = spatial_pair_set(
+        matlab["positions"],
+        matlab["connections"],
+        positions_are_one_based=matlab_positions_one_based,
+        connection_indices_one_based=matlab_connections_one_based,
+    )
+    p_spatial = spatial_pair_set(
+        python["positions"],
+        python["connections"],
+        positions_are_one_based=python_positions_one_based,
+        connection_indices_one_based=py_conn_one_based,
+    )
+    if m_spatial != p_spatial:
+        return "edges"
+
+    m_n = matlab.get("n_strands")
+    p_n = python.get("n_strands")
+    if m_n != p_n:
+        return "strands"
+
+    m_raw = matlab.get("strands2vertices", matlab.get("strands"))
+    p_raw = python.get("strands")
+    if m_raw is not None and p_raw is not None:
+        m_pairs = strand_endpoint_pair_multiset(m_raw, indices_one_based=True)
+        p_pairs = strand_endpoint_pair_multiset(p_raw, indices_one_based=False)
+        if m_pairs != p_pairs:
+            return "strands"
+    elif m_n is None or p_n is None:
+        raise NonComparableArtifactsError("strand counts missing on one or both sides")
+    return None
+
+
+def localize_stage_compare(
+    matlab: dict[str, Any],
+    python: dict[str, Any],
+    *,
+    previously_reported_strand_break: bool = False,
+) -> dict[str, Any]:
+    """Build a durable localization payload for one dual-run rung.
+
+    Never offers Python candidates vs MATLAB finals as a discovery verdict.
+    """
+    try:
+        stage = first_diff_stage(matlab, python)
+    except NonComparableArtifactsError as exc:
+        return {
+            "comparable": False,
+            "reason": str(exc),
+            "first_diff_stage": None,
+            "outcome": "inconclusive",
+            "note": LOCALIZATION_NON_CERTIFICATION_NOTE,
+        }
+
+    cand_m = _candidate_pair_set(matlab)
+    cand_p = _candidate_pair_set(python)
+    candidates_status: Literal["unavailable", "match", "mismatch"]
+    if cand_m is None or cand_p is None:
+        candidates_status = "unavailable"
+    elif cand_m == cand_p:
+        candidates_status = "match"
+    else:
+        candidates_status = "mismatch"
+
+    m_raw = matlab.get("strands2vertices", matlab.get("strands"))
+    p_raw = python.get("strands")
+    m_pairs = (
+        strand_endpoint_pair_multiset(m_raw, indices_one_based=True)
+        if m_raw is not None
+        else Counter()
+    )
+    p_pairs = (
+        strand_endpoint_pair_multiset(p_raw, indices_one_based=False)
+        if p_raw is not None
+        else Counter()
+    )
+    inter = sum((m_pairs & p_pairs).values())
+    union = sum((m_pairs | p_pairs).values()) or 1
+
+    if stage is None:
+        outcome = "measurement_fixed_match" if previously_reported_strand_break else "match"
+    else:
+        outcome = "first_diff"
+
+    return {
+        "comparable": True,
+        "first_diff_stage": stage,
+        "outcome": outcome,
+        "note": LOCALIZATION_NON_CERTIFICATION_NOTE,
+        "stages": _ordered_stage_statuses(stage, candidates_status=candidates_status),
+        "counts": {
+            "matlab_strands": matlab.get("n_strands"),
+            "python_strands": python.get("n_strands"),
+        },
+        "strand_endpoint_multiset": {
+            "n_matlab": sum(m_pairs.values()),
+            "n_python": sum(p_pairs.values()),
+            "n_intersection": inter,
+            "n_only_matlab": sum((m_pairs - p_pairs).values()),
+            "n_only_python": sum((p_pairs - m_pairs).values()),
+            "overlap_pct_of_union": 100.0 * inter / union,
+        },
+        "same_class_guard": (
+            "candidates compared only when both sides expose candidate_connections; "
+            "Python candidates are never compared to MATLAB final edges"
+        ),
+    }
 
 
 def strict_compare_summary(

--- a/tests/integration/parity/test_synthetic_rung_localization_live.py
+++ b/tests/integration/parity/test_synthetic_rung_localization_live.py
@@ -1,0 +1,71 @@
+"""Live-MATLAB gated localization smoke for double_junction_32.
+
+Excluded from the default unit CI gate via ``parity`` + ``slow`` markers.
+Skips cleanly when MATLAB is not installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LADDER_SCRIPT = REPO_ROOT / "scripts" / "run_synthetic_complexity_ladder.py"
+
+
+def _load_ladder_module():
+    spec = importlib.util.spec_from_file_location(
+        "run_synthetic_complexity_ladder",
+        LADDER_SCRIPT,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def ladder_mod():
+    return _load_ladder_module()
+
+
+@pytest.mark.parity
+@pytest.mark.slow
+@pytest.mark.integration
+def test_live_localize_double_junction_32_schema(ladder_mod):
+    matlab = ladder_mod.resolve_matlab_exe()
+    if matlab is None:
+        pytest.skip("MATLAB executable not found")
+
+    report = ladder_mod.run_localize(
+        "double_junction_32",
+        skip_matlab=False,
+        reuse_python=False,
+    )
+    loc = report["localization"]
+    assert "NOT Certification" in report["note"]
+    assert report["claim_of_record"] is True
+    assert report["rung_id"] == "double_junction_32"
+    assert Path(report["report_path"]).is_file()
+
+    payload = json.loads(Path(report["report_path"]).read_text(encoding="utf-8"))
+    assert "localization" in payload
+    assert "NOT Certification" in payload["note"]
+
+    # Loader must not spuriously report MATLAB strand count 1 when N>1.
+    m_count = (loc.get("counts") or {}).get("matlab_strands")
+    if loc.get("comparable") and m_count is not None:
+        assert m_count != 1 or (loc.get("counts") or {}).get("python_strands") == 1
+
+    assert loc.get("outcome") in {
+        "match",
+        "measurement_fixed_match",
+        "first_diff",
+        "inconclusive",
+    }

--- a/tests/unit/analytics/parity/test_synthetic_dual_run_compare.py
+++ b/tests/unit/analytics/parity/test_synthetic_dual_run_compare.py
@@ -7,7 +7,10 @@ import pytest
 
 from slavv_python.analytics.parity.probes.synthetic_dual_run_compare import (
     NonComparableArtifactsError,
+    count_matlab_strands2vertices,
     first_break_surface,
+    first_diff_stage,
+    localize_stage_compare,
     strict_compare_summary,
 )
 
@@ -93,3 +96,90 @@ def test_incomplete_artifacts_raise_and_summary_non_comparable():
     summary = strict_compare_summary(matlab, python)
     assert summary["comparable"] is False
     assert summary["first_break_surface"] is None
+
+
+# --- U1: MATLAB strands2vertices counting (AE1) ---
+
+
+@pytest.mark.unit
+def test_ae1_numeric_3x2_matlab_strands_count_as_three():
+    """Live double_junction_32 mats are numeric (3, 2); must not count as 1."""
+    strands = np.asarray([[1, 2], [2, 3], [1, 3]], dtype=np.uint8)
+    assert count_matlab_strands2vertices(strands) == 3
+
+
+@pytest.mark.unit
+def test_matlab_object_cell_strands_count_as_three():
+    cell = np.empty((3,), dtype=object)
+    cell[0] = np.asarray([1, 2], dtype=np.uint8)
+    cell[1] = np.asarray([2, 3], dtype=np.uint8)
+    cell[2] = np.asarray([1, 3], dtype=np.uint8)
+    assert count_matlab_strands2vertices(cell) == 3
+
+
+@pytest.mark.unit
+def test_matlab_single_row_or_vector_strands_count_as_one():
+    assert count_matlab_strands2vertices(np.asarray([[4, 7]], dtype=np.int64)) == 1
+    assert count_matlab_strands2vertices(np.asarray([4, 7], dtype=np.int64)) == 1
+
+
+@pytest.mark.unit
+def test_matlab_missing_strands_count_is_none():
+    assert count_matlab_strands2vertices(None) is None
+
+
+# --- U2: stage localization + endpoint multisets ---
+
+
+@pytest.mark.unit
+def test_strand_endpoint_multiset_mismatch_is_first_diff_strands():
+    matlab = _side([[2, 2, 2], [5, 5, 5], [8, 8, 8]], [[1, 2], [2, 3]], 2)
+    python = _side([[1, 1, 1], [4, 4, 4], [7, 7, 7]], [[0, 1], [1, 2]], 2)
+    # Counts match (2) but endpoint pairs differ after 0-based normalize.
+    matlab["strands2vertices"] = np.asarray([[1, 2], [2, 3]], dtype=np.int64)
+    python["strands"] = [np.asarray([0, 2]), np.asarray([1, 2])]  # ends (0,2),(1,2)
+    assert first_diff_stage(matlab, python) == "strands"
+
+
+@pytest.mark.unit
+def test_first_diff_all_match_returns_none():
+    matlab = _side([[2, 2, 2], [5, 5, 5]], [[1, 2]], 1)
+    python = _side([[1, 1, 1], [4, 4, 4]], [[0, 1]], 1)
+    matlab["strands2vertices"] = np.asarray([[1, 2]], dtype=np.int64)
+    python["strands"] = [np.asarray([0, 1])]
+    assert first_diff_stage(matlab, python) is None
+    loc = localize_stage_compare(matlab, python, previously_reported_strand_break=True)
+    assert loc["outcome"] == "measurement_fixed_match"
+    assert "NOT Certification" in loc["note"]
+    assert loc["stages"]["candidates"] == "unavailable"
+
+
+@pytest.mark.unit
+def test_candidates_unavailable_still_compares_edges():
+    matlab = _side(
+        [[2, 2, 2], [5, 5, 5], [8, 8, 8]],
+        [[1, 2], [2, 3]],
+        2,
+    )
+    python = _side(
+        [[1, 1, 1], [4, 4, 4], [7, 7, 7]],
+        [[0, 1]],  # missing edge
+        2,
+    )
+    # Only Python has candidates — must not invent a candidates verdict.
+    python["candidate_connections"] = np.asarray([[0, 1]], dtype=np.int64)
+    assert first_diff_stage(matlab, python) == "edges"
+
+
+@pytest.mark.unit
+def test_ae3_candidates_not_compared_to_matlab_finals():
+    """Python candidates vs MATLAB finals must not become a discovery residual."""
+    matlab = _side([[2, 2, 2], [5, 5, 5]], [[1, 2]], 1)
+    python = _side([[1, 1, 1], [4, 4, 4]], [[0, 1]], 1)
+    matlab["strands2vertices"] = np.asarray([[1, 2]], dtype=np.int64)
+    python["strands"] = [np.asarray([0, 1])]
+    python["candidate_connections"] = np.asarray([[0, 1], [0, 0]], dtype=np.int64)
+    loc = localize_stage_compare(matlab, python)
+    assert loc["stages"]["candidates"] == "unavailable"
+    assert loc["first_diff_stage"] is None
+    assert "never compared to MATLAB final" in loc["same_class_guard"]


### PR DESCRIPTION
﻿## Summary
- Fix MATLAB `strands2vertices` counting so numeric `(N, 2)` matrices count as N strands (not 1) — the published double_junction 1-vs-3 stop was a loader bug.
- Add stage-ordered localization helpers (vertices → candidates → edges → strands) with endpoint-pair multisets and same-class guards.
- Add `--localize` on the synthetic complexity ladder for live MATLAB dual-run reports (`measurement_fixed_match` / first differing stage); not Certification / not ADR 0013.

## Test plan
- [x] Unit tests for dual-run compare + ladder report helpers
- [x] Live localize on double_junction_32 → measurement_fixed_match
- [x] Historical (3,2) batch recount → 3 vs 3 with 100% endpoint multiset overlap
- [ ] Optional live gated pytest on MATLAB machines: tests/integration/parity/test_synthetic_rung_localization_live.py

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — investigation harness / ladder tooling only; does not change production pipeline stages or claim roots.

## Known Residuals
- Code review: manual diff scan (nested ce-code-review skipped while running as parent subagent); no independent multi-persona corroboration claimed.
- Fresh live dual-run can emit 1 strand on both sides (topology varies); historical 3-strand batch also matches after recount. Full ladder advance past rung 2 not re-run in this PR.
- MATLAB raw Candidate Set export still unavailable on the ladder .m driver (candidates stage stays unavailable).

## Summary by Sourcery

Introduce a strand-aware divergence localization harness on the synthetic complexity ladder, correcting MATLAB strand counting and adding stage-ordered compare and reporting for dual-run investigations.

New Features:
- Add stage-localization helpers that compute first differing stage across vertices, candidates, edges, and strands, including endpoint-pair multiset comparison and structured outcomes.
- Add a localization mode to the synthetic complexity ladder script, with a CLI flag to run live MATLAB dual-run for a single rung and emit a durable localization_report.json payload.

Bug Fixes:
- Correct MATLAB strands2vertices counting so numeric (N,2) matrices and other forms yield the correct strand count instead of collapsing to one, resolving the historical double_junction_32 1-vs-3 measurement bug.

Enhancements:
- Tighten strand comparison logic in strict dual-run summaries by requiring endpoint-pair multiset agreement when payloads are present.
- Extend artifact loaders to retain strand payloads for both MATLAB and Python sides, enabling richer localization and overlap metrics.
- Add non-Certification guardrails and same-class comparison rules so candidates are only compared when available on both sides and Python candidates are never treated as mismatches against MATLAB finals.

Documentation:
- Add an implementation-ready product/technical plan documenting the double-junction strand divergence investigation harness, its scope, requirements, flows, and verification contract.

Tests:
- Add unit tests covering MATLAB strand counting, stage localization behavior, candidate availability handling, and measurement-fixed outcomes.
- Add a live-MATLAB gated integration test that runs localization for double_junction_32, validates report schema and notes, and ensures corrected strand counting under real dual-run conditions.