### PR TITLE
feat(parity): true zero-tolerance stretch foundation (U1–U7)

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -46,6 +46,16 @@ status. When findings [ONE TRUTH](../docs/reference/core/EXACT_PROOF_FINDINGS.md
 2. **Network ADR 0012** — met on the same claim root (see ONE TRUTH).
 3. **Strict-field stretch** — exact connections / order remain optional non-blocking follow-up on crop.
 
+### True zero-tolerance stretch (operator notes)
+
+Labeled **stretch** — does **not** reopen Phase 1 CLOSED / ONE TRUTH.
+
+- Compare with `slavv parity prove-exact … --strict-floats` (default allclose ≠ stretch success).
+- Crop Energy unlock first (`crop_M_exact_v3` lineage / `180709_E_crop_M_v2`); full `180709_E` only after a matching unlock field set.
+- Never overwrite `canonical_full_v18`; use a new stretch dest root.
+- Status helpers: `slavv_python.analytics.parity.proof.stretch` (`gate_full_stretch_entry`, unlock + taxonomy).
+- Plan: [docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md](../docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md).
+
 ### Primary loop KPI
 
 | KPI | Surface | Role |

--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -55,7 +55,7 @@ Labeled **stretch** — does **not** reopen Phase 1 CLOSED / ONE TRUTH.
 - Engine float path: isolated Python 3.7 + `matlab.engine` (R2019a). Repo `.venv` is 3.12. Set `STRETCH_PY37_PYTHON`, then:
   ```powershell
   slavv parity resume-exact-run `
-    --dest-run-root workspace\runs\oracle_180709_E\crop_M_stretch_engine_v1 `
+    --dest-run-root workspace\runs\oracle_180709_E\crop_M_stretch_engine_v2 `
     --oracle-root workspace\oracles\180709_E_crop_M_v2 `
     --dataset-root workspace\datasets\0cdf88e930482e9eb818963da22846c43b53b531582bf3aed83678b549863d06 `
     --force-rerun-from energy --stop-after energy --n-jobs 1 `

--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -52,6 +52,15 @@ Labeled **stretch** — does **not** reopen Phase 1 CLOSED / ONE TRUTH.
 
 - Compare with `slavv parity prove-exact … --strict-floats` (default allclose ≠ stretch success).
 - Crop Energy unlock first (`crop_M_exact_v3` lineage / `180709_E_crop_M_v2`); full `180709_E` only after a matching unlock field set.
+- Engine float path: isolated Python 3.7 + `matlab.engine` (R2019a). Repo `.venv` is 3.12. Set `STRETCH_PY37_PYTHON`, then:
+  ```powershell
+  slavv parity resume-exact-run `
+    --dest-run-root workspace\runs\oracle_180709_E\<new_crop_stretch_root> `
+    --oracle-root workspace\oracles\180709_E_crop_M_v2 `
+    --force-rerun-from energy --stop-after energy --n-jobs 1 `
+    --energy-float-backend matlab_engine
+  slavv parity prove-exact --stage energy --strict-floats ...
+  ```
 - Never overwrite `canonical_full_v18`; use a new stretch dest root.
 - Status helpers: `slavv_python.analytics.parity.proof.stretch` (`gate_full_stretch_entry`, unlock + taxonomy).
 - Plan: [docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md](../docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md).

--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -55,8 +55,9 @@ Labeled **stretch** — does **not** reopen Phase 1 CLOSED / ONE TRUTH.
 - Engine float path: isolated Python 3.7 + `matlab.engine` (R2019a). Repo `.venv` is 3.12. Set `STRETCH_PY37_PYTHON`, then:
   ```powershell
   slavv parity resume-exact-run `
-    --dest-run-root workspace\runs\oracle_180709_E\<new_crop_stretch_root> `
+    --dest-run-root workspace\runs\oracle_180709_E\crop_M_stretch_engine_v1 `
     --oracle-root workspace\oracles\180709_E_crop_M_v2 `
+    --dataset-root workspace\datasets\0cdf88e930482e9eb818963da22846c43b53b531582bf3aed83678b549863d06 `
     --force-rerun-from energy --stop-after energy --n-jobs 1 `
     --energy-float-backend matlab_engine
   slavv parity prove-exact --stage energy --strict-floats ...

--- a/docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md
+++ b/docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md
@@ -1,0 +1,535 @@
+---
+title: True Zero-Tolerance Parity Stretch - Plan
+type: feat
+date: 2026-08-14
+topic: true-zero-tolerance-parity-stretch
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+deepened: 2026-08-14
+---
+
+# True Zero-Tolerance Parity Stretch - Plan
+
+## Goal Capsule
+
+- **Objective:** Build a stretch program that makes every compared MATLAB↔Python field truly zero-tolerance (including Energy floats bit-equal to MATLAB), using a MATLAB-engine Energy float path as needed, proven on the crop harness first and only then on full `180709_E`.
+- **Product authority:** This plan owns the post–Phase 1 true zero-tolerance stretch only. Phase 1 Certification on claim root `canonical_full_v18` stays CLOSED and is not redefined or reopened.
+- **Open blockers:** None for planning. Delivery may stay incomplete if no float path yields bit-equal Energy; that outcome is “blocked,” not a silent return to `np.allclose`.
+- **Execution profile:** code — implement behind exact-route Energy + existing `--strict-floats` proof surfaces; no Phase 1 ship-bar changes.
+- **Stop when:** Crop then full zero-tolerance proofs pass for the **full** R1+R2 field set under the engine-backed path (`stretch_complete`), **or** the program is explicitly recorded as `blocked_float_path` / `incomplete_discrete` / `incomplete_infra` / `incomplete_at_full` without redefining success as ADR 0011 allclose.
+- **Product Contract preservation:** Product Contract unchanged (R1–R10, A1–A3, F1–F2, AE1–AE4, KD1–KD5 preserved).
+
+---
+
+## Product Contract
+
+### Summary
+
+Pursue true zero-tolerance parity as a stretch beyond closed Phase 1. Prefer a MATLAB-engine path for Energy float-sensitive math so Python can match MATLAB bit-for-bit. Prove on the crop harness with a zero-tolerance compare gate, then on full `180709_E`. Discrete strict fields (exact connections / order-sensitive emission) sit under the same bar.
+
+Plan coverage: full brainstorm scope. Energy-first crop unlock may authorize Energy-only full proof (ASSUME1); discrete strict-field expands the unlock field set under the same bar; full volume runs only for a matching unlocked field set. `stretch_complete` requires Energy **and** discrete (R2) at full — Energy-only full progress is intermediate, not program complete. Stretch status lives beside ONE TRUTH without mutating CLOSED Phase 1 language.
+
+### Problem Frame
+
+Phase 1 Certification already passes ADR 0011 / evaluated ADR 0012 on `canonical_full_v18`, but “100% parity” still sounds unfinished to operators who mean bit-identical fields. ADR 0011 documents real NumPy vs MATLAB MKL Energy float drift and chose `np.allclose` for the ship gate. Without an explicit stretch program, teams either reopen Phase 1 or quietly redefine “100%” as the bars already met.
+
+### Key Decisions
+
+- KD1. **True zero-tolerance everywhere, including Energy floats.** (session-settled: user-directed — chosen over Phase-1-bars-as-100%, strict-field-only, more-volumes-only, or softer float tolerance: “100%” means every compared field bit-equal to MATLAB.) Governs R1, R2, R3.
+- KD2. **Build now; MATLAB-engine / MKL float path is in-scope.** (session-settled: user-directed — chosen over document-only aspirational or spike-only: commit to building toward the bar.) Governs R4, R5.
+- KD3. **Approach A — MATLAB-engine Energy float path.** (session-settled: user-approved — chosen over MKL-only hope or MATLAB-writes-Energy hybrid: clearest path to bit-equal Energy from a Python-owned pipeline.) Governs R4, R6.
+- KD4. **Crop first, then full `180709_E`.** (session-settled: user-directed — chosen over full-only or crop-only: cheap falsification before multi-day full runs.) Governs R7, R8.
+- KD5. **Phase 1 Certification stays CLOSED.** (session-settled: user-directed — chosen over reopening the ship gate: stretch does not change ADR 0011/0012 certification standing.) Governs R9, R10.
+
+<!-- ce-section: work-relationships -->
+### How This Work Fits Together
+
+This plan owns the **true zero-tolerance parity stretch** only. Surrounding areas below are the current understanding, not a committed roadmap.
+
+- Phase 1 Certification (`canonical_full_v18`, ONE TRUTH CLOSED)
+  - **Outside** this plan’s identity; must remain CLOSED
+  - **Can proceed independently of** this stretch (already done)
+- Documented Strict-Field Stretch Goal (exact connections / order on crop)
+  - **Shares** discrete zero-tolerance outcomes with this plan’s bar
+  - **Folded into** this program rather than a separate product outcome
+- Paper-profile / Phase 2 certification, matlab2python audits, unrelated PR tracks
+  - **Can proceed independently of** this stretch
+  - **Outside** this plan’s identity unless a later brainstorm pulls them in
+
+### Actors
+
+- A1. Parity operator — runs crop then full zero-tolerance proofs; does not promote stretch results into Phase 1 ONE TRUTH closure language.
+- A2. Planning / implementation agent — designs the MATLAB-engine Energy path and zero-tolerance proof wiring without inventing a softer success bar.
+- A3. MATLAB runtime environment — must be available where the engine-backed Energy path runs.
+
+### Requirements
+
+**Zero-tolerance bar**
+
+- R1. Every field compared in the stretch proof must match MATLAB with **zero remaining tolerance** (bit-equal / strict equality as appropriate to the field type), including continuous Energy floats.
+- R2. Discrete Edges/Network strict fields (exact `connections` / order-sensitive emission) are **in** this same bar, not a separate optional product.
+- R3. If Energy floats never become bit-equal under any in-scope float path, the program status is **incomplete / blocked** — not redefined as Phase 1 `np.allclose` success.
+
+**Float path**
+
+- R4. The primary delivery path uses a **MATLAB-engine Energy float path** so float-sensitive Energy math can match MATLAB while Python still owns pipeline orchestration.
+- R5. An MKL-matched in-process library path may be used only as a short falsifying alternative if it demonstrably yields bit-equal Energy; it does not replace R4 as the default commitment without a later scope change.
+- R6. A hybrid where MATLAB alone writes the Energy artifact and Python never produces Energy does **not** satisfy this stretch’s “Python zero-tolerance” intent.
+
+**Proof ladder**
+
+- R7. Zero-tolerance must first pass on the **crop harness** volume paired with its oracle.
+- R8. Full `180709_E` zero-tolerance proof runs **only after** crop zero-tolerance passes for the fields under test.
+
+**Phase 1 boundary**
+
+- R9. Phase 1 Certification on `canonical_full_v18` remains CLOSED; stretch proofs must not reopen or rewrite the ADR 0011 / evaluated ADR 0012 ship bars.
+- R10. Stretch progress must not be described as Phase 1 Certification closure or as replacing ONE TRUTH’s CLOSED answer.
+
+### Key Flows
+
+- F1. Crop zero-tolerance proof
+  - **Trigger:** Operator (or automation) starts a stretch proof after an engine-backed Energy path is available.
+  - **Actors:** A1, A2, A3
+  - **Steps:** Produce crop Energy (and downstream stages as required) via the MATLAB-engine float path; compare all in-scope fields to the crop oracle under zero-tolerance; stop on first bit-level failure with a clear field surface.
+  - **Outcome:** Crop pass emits an unlock for a **named field set** (Energy-only or Energy+discrete); that unlock alone authorizes F2 for the same set. Crop fail means stretch incomplete for that surface.
+  - **Covered by:** R1, R3, R4, R7, R8
+
+- F2. Full-volume zero-tolerance proof
+  - **Trigger:** F1 passed for the fields under test.
+  - **Actors:** A1, A2, A3
+  - **Steps:** Run the same zero-tolerance compare on full `180709_E` against the full oracle lineage; do not claim Phase 1 reopen.
+  - **Outcome:** Full pass = stretch success for this volume; fail = incomplete / blocked at full scale.
+  - **Covered by:** R1, R8, R9, R10
+
+### Acceptance Examples
+
+- AE1. Crop Energy floats still differ by ULP under NumPy-only Energy
+  - **Covers:** R1, R3, R4
+  - **Given:** Crop harness and current NumPy Energy path
+  - **When:** Zero-tolerance Energy compare runs without the MATLAB-engine path
+  - **Then:** Proof fails on Energy floats; status is incomplete, not “allclose is good enough for this stretch”
+
+- AE2. Crop passes only after engine-backed Energy
+  - **Covers:** R4, R7
+  - **Given:** MATLAB-engine Energy float path available and crop oracle present
+  - **When:** Zero-tolerance crop proof runs end-to-end for compared fields
+  - **Then:** Every compared field matches with zero tolerance, including Energy floats
+
+- AE3. Full volume gated by crop
+  - **Covers:** R7, R8
+  - **Given:** Crop zero-tolerance has not passed
+  - **When:** Operator attempts full `180709_E` stretch proof as the first gate
+  - **Then:** Full run is refused or treated as out of process for this plan’s success definition
+
+- AE4. Phase 1 language unchanged
+  - **Covers:** R9, R10
+  - **Given:** Stretch crop or full proof is green or red
+  - **When:** Status is reported in operator docs
+  - **Then:** ONE TRUTH still says Phase 1 CLOSED; stretch is labeled stretch / blocked / complete separately
+
+### Success Criteria
+
+- Crop harness shows zero-tolerance match on every compared field, including Energy floats, under the engine-backed path.
+- Full `180709_E` shows the same only after crop success.
+- Phase 1 Certification messaging remains CLOSED on `canonical_full_v18`.
+- A durable failure mode exists: “blocked on float path” rather than silently accepting tolerance.
+
+### Scope Boundaries
+
+**In scope**
+
+- MATLAB-engine Energy float path as the primary mechanism
+- Zero-tolerance proof ladder: crop → full `180709_E`
+- Discrete strict-field equality under the same bar
+
+**Deferred for later**
+
+- Additional volumes beyond `180709_E` / its crop harness
+- Paper-profile certification and Phase 2 program work
+- Broad packaging/distribution of a MATLAB-engine dependency for all users
+
+**Deferred to Follow-Up Work**
+
+- Zero-tolerance compare for Vertices/Edges continuous float fields (radii, non-Energy energies) after Energy-stage floats close — still under R1 in principle (ASSUME5), not in U1–U7 DoD
+
+**Outside this product's identity**
+
+- Reopening Phase 1 Certification or changing ADR 0011/0012 ship gates
+- Claiming “100% parity” from Phase 1 spatial/tolerance bars alone
+- matlab2python static-transpiler audits as the verification path
+- Hybrid MATLAB-only Energy writer as the stretch success definition (R6)
+
+### Dependencies / Assumptions
+
+- MATLAB R2019a-compatible runtime (or the project’s documented MATLAB version) is available on machines that run the engine-backed Energy path.
+- Crop and full oracles for `180709_E` remain the compare surfaces; this stretch does not invent a new certification volume.
+- ADR 0011’s measured NumPy↔MKL drift remains the reason a MATLAB-linked float path is required for Energy bit equality.
+- Existing zero-tolerance / strict-float compare capability in the proof harness may be reused; planning owns wiring details.
+
+### Outstanding Questions
+
+**Resolve Before Planning**
+
+- None.
+
+**Deferred to Implementation**
+
+- Exact `.m` entry surface inside Vectorization-Public (per-scale filter vs whole octave body) once engine transfer cost is measured on crop.
+- Whether stretch CLI gains a named alias vs documenting `prove-exact --strict-floats` as the stretch gate.
+- Exact stretch run-directory naming food-codenames at launch time.
+
+---
+
+## Planning Contract
+
+### Assumptions
+
+Recorded because scoping confirmation was skipped (recommended defaults):
+
+- ASSUME1. **Energy-first unlock (intermediate).** Crop Energy under `--strict-floats` may unlock Energy-only F2 before discrete is green. Energy-only full green is progress, **not** `stretch_complete`. Discrete failure is `incomplete_discrete`, not R3 `blocked_float_path`. Program complete (`stretch_complete`) requires R2 discrete at full as well.
+- ASSUME2. **Stretch status home.** A dedicated stretch subsection (or sidecar note linked from findings) records stretch state; ONE TRUTH Phase 1 CLOSED text is never rewritten by stretch greens/reds.
+- ASSUME3. **MKL spike is optional.** Not a required gate before engine work; may run only as a short falsifier. An MKL crop bit-equal result does **not** replace Approach A without a later scope change.
+- ASSUME4. **CI does not require MATLAB.** Default unit/integration CI skips engine tests when MATLAB/engine is absent; stretch proofs run on operator hosts with MATLAB.
+- ASSUME5. **First delivery units own Energy-stage floats.** Vertex/edge continuous energies remain under R1 in principle but are **Deferred to Follow-Up Work** for a later unit unless crop Energy work already surfaces them; do not claim first-unit DoD covers them.
+- ASSUME6. **Stretch writers are serial-first** (`n_jobs=1`) until engine+merge bit-identity is proven; parallel chunk merge remains a follow-on verification, not a day-one requirement.
+
+### Key Technical Decisions
+
+- KTD1. **Reuse `--strict-floats` as the stretch compare gate; do not change ADR 0011 defaults.** Default `prove-exact` stays allclose for Certification. Stretch proofs always pass `--strict-floats` (and/or a thin stretch wrapper that forces it). Governs R1, R9.
+- KTD2. **Greenfield MATLAB-engine adapter behind exact-route Energy; keep `EnergyManager` orchestration.** No `matlab.engine` exists today (only `-batch` in random-component parity). Add a small adapter + explicit energy origin distinct from `python_native_hessian`. Pattern discovery on `MATLAB_EXE` / prerequisites may be shared with `tests/support/random_component_parity.py`, but the float path uses in-process engine, not batch-as-success. Instantiates KD3 / R4, R6.
+- KTD3. **Minimize Python↔MATLAB crossings for float math.** Prefer one long-lived engine per Energy job and a single MATLAB entry that owns FFT/filter (or octave float body) before returning one result — R2019a-era marshalling of large 3D arrays is expensive; avoid per-chunk `start_matlab` and `.tolist()` round-trips. Instantiates R4.
+- KTD4. **Hard crop→full unlock token scoped by field set.** F2 entry requires a recorded crop unlock for the same field set (Energy-only vs full pipeline). Checklist-only AE3 is insufficient. Instantiates R7, R8 / AE3.
+- KTD5. **Status taxonomy separates failure classes.** At least: `blocked_float_path` (R3), `incomplete_discrete` (R2 after Energy green), `incomplete_infra` (MATLAB/engine/version/license), `incomplete_at_full` (full fail after unlock), plus progress states such as `crop_energy_passed`. `stretch_complete` means full R1+R2 (Energy **and** discrete) at full volume — not Energy-only. Never map infra failure to R3. Instantiates R2, R3, AE4.
+- KTD6. **New stretch dest run roots only.** Never overwrite `canonical_full_v18` or historical claim/audit roots. Prefer `crop_M_exact_v3` lineage for crop stretch; new canonical stretch root for full. Instantiates R9, R10.
+- KTD7. **Provenance refuse mixed float paths.** Stretch proofs reject Energy checkpoints that mix NumPy FFT and engine-backed voxels, or that lack the stretch origin stamp. Instantiates R4, R6, AE2.
+- KTD8. **MKL spike is optional falsifier only.** Does not unlock stretch complete or replace KTD2. Instantiates R5.
+
+### High-Level Technical Design
+
+#### Component topology
+
+```mermaid
+flowchart LR
+  EM[EnergyManager orchestration]
+  AD[MATLAB-engine adapter]
+  ML[MATLAB float entry .m]
+  CK[Energy checkpoint + origin stamp]
+  PR[prove-exact --strict-floats]
+  UL[Crop unlock token]
+  ST[Stretch status surface]
+
+  EM --> AD
+  AD --> ML
+  ML --> AD
+  AD --> CK
+  CK --> PR
+  PR -->|crop Energy green| UL
+  UL -->|same field set| PR
+  PR --> ST
+```
+
+#### Proof ladder / state machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> stretch_not_started
+  stretch_not_started --> float_path_building: engine adapter work
+  float_path_building --> incomplete_infra: MATLAB missing / engine crash
+  float_path_building --> crop_energy_running: engine ready
+  crop_energy_running --> blocked_float_path: Energy bit-equal fails after engine
+  crop_energy_running --> crop_energy_passed: Energy --strict-floats green
+  crop_energy_passed --> crop_discrete_running: optional next
+  crop_discrete_running --> incomplete_discrete: connections/order fail
+  crop_energy_passed --> full_refused: F2 without unlock
+  crop_energy_passed --> full_running: unlock + same field set
+  crop_discrete_running --> full_running: discrete unlock too
+  full_running --> stretch_complete: full zero-tol pass
+  full_running --> incomplete_at_full: full fail
+  note right of stretch_not_started
+    Phase 1 CLOSED invariant
+    never transitions
+  end note
+```
+
+#### Data-flow note (directional)
+
+Python owns params, lattice/chunk scheduling, resume, and checkpoint packaging. MATLAB owns float-sensitive Energy transforms for the stretch origin. Return path must preserve Fortran-order `[Y, X, Z]` alignment with the exact-route grid. Oracle compare uses existing loaders + `evaluate_energy_float_gate` with `strict_floats=True`.
+
+### Alternative Approaches Considered
+
+| Approach | Why not primary |
+|:---------|:----------------|
+| MKL-matched NumPy as default | ADR 0010/0011 show ≥1 ULP IFFT floor; portable CNR hope is weak; allowed only as R5 falsifier (KTD8) |
+| MATLAB-only Energy writer | Violates R6 — Python must produce Energy under orchestration |
+| Change ADR 0011 ship default to bit-equal | Reopens Phase 1; violates KD5 / R9 |
+| Full volume before crop | Violates KD4 / R7–R8; crop≠full history (high-octave divergence) |
+
+### Risks & Dependencies
+
+| Risk | Mitigation |
+|:-----|:-----------|
+| No engine bridge today | Build U2 adapter; fail as `incomplete_infra` if engine cannot start |
+| R2019a large-array marshalling dominates wall time | Measure crop transfer once (KTD3); one engine + one `.m` return; budget full ETA separately; timeout → `incomplete_infra` |
+| Partial MATLAB surface leaves residual ULP | Expand float ownership inside Energy until crop Energy `==`; never declare complete on allclose |
+| Crop green ≠ full Energy / high-octave multi-chunk | F2 after unlock; re-verify octaves per `docs/solutions/parity/canonical-energy-high-octave-divergence.md` |
+| Full-volume orientation `(512,64,512)` vs oracle | Follow `docs/solutions/parity/resume-energy-orientation.md`; assert shape before `--strict-floats`; refuse unlock on mismatch |
+| Silent allclose / default `prove-exact` as stretch green | Unlock only on `--strict-floats` green; taxonomy forbids rewriting R3 as ADR 0011 success |
+| Mixed provenance / wrong run root | KTD6–KTD7; refuse stretch proof on Phase 1 claim roots and mixed origins |
+| Discrete residual after bit-equal Energy | Sequence U5; label `incomplete_discrete` |
+| License seat contention / engine attach mid-job | Serial-first (ASSUME6); map license/engine errors to `incomplete_infra`, never `blocked_float_path` |
+| Engine Python version pin ≠ repo/CI Python | Pin operator host Python in stretch docs; CI skips engine tests (ASSUME4) |
+
+### System-Wide Impact
+
+- **Operators (A1):** New stretch run roots, unlock discipline, status vocabulary; Phase 1 dashboards unchanged.
+- **Writer lease:** Stretch Energy writers use `slavv_python/analytics/parity/runs/writer_lease.py` / `writer_session.py`. No second writer on the same dest root while a lease is live; reconcile stale leases before claim.
+- **Resume / force-rerun:** Engine origin and unlock tokens must survive `resume-exact-run` / `launch-exact-run`. Changing float path or `n_jobs` requires `--force-rerun-from energy`; never force-rerun on `canonical_full_v18`.
+- **Concurrent jobs:** Check `slavv jobs list` before stretch writers; food-codenames are aliases only — lease/job registry remains authority.
+- **Streamlit vs CLI:** Stretch gates (`--strict-floats`, unlock, engine origin) are CLI-first (`slavv parity …`). Streamlit must not imply stretch success or bypass unlock.
+- **Oracle loaders:** Keep `oracle/matlab_vector_loader.py` / `python_checkpoint_loader.py` / `surfaces.py` — no stretch-only loader that softens Energy floats.
+- **Proof CLI:** Do not change default ADR 0011 allclose in `commands.py` / `coordinator.py`; only `--strict-floats` (or a thin wrapper) drives stretch unlock.
+- **Provenance consumers:** Stretch engine stamps stay distinct from `python_native_hessian` so mixed checkpoints fail stretch proofs.
+- **CI:** Optional/skipped engine tests; default Certification proofs unchanged.
+- **Packaging:** Do not add MATLAB Engine to `pyproject.toml` `[app]` / `[workspace]`; operator install stays beside ASSUME4 (broad packaging remains Deferred).
+- **Docs:** Stretch subsection + ADR cross-links; do not edit ONE TRUTH CLOSED claim language.
+
+### Phased Delivery
+
+1. **Phase A — Float path + crop Energy zero-tol** (U1–U4): status surface, engine adapter, Energy dispatch, crop Energy unlock.
+2. **Phase B — Discrete crop** (U5): strict connections/order under same bar.
+3. **Phase C — Full volume** (U6): gated F2 for unlocked field set. Energy-only full may follow Phase A unlock without Phase B complete; `stretch_complete` still requires Phase B discrete unlock + full discrete green.
+4. **Optional — MKL spike** (U7): short falsifier only; may run anytime without replacing Phase A.
+
+### Documentation Plan
+
+- Stretch status subsection linked from `docs/reference/core/EXACT_PROOF_FINDINGS.md` without mutating ONE TRUTH CLOSED body.
+- Operator notes in `.claude/HANDOFF.md` (stretch commands + unlock rule) labeled stretch.
+- Pointer from ADR 0011 Option A/D history to this plan as the active stretch program (no ADR ship-bar rewrite).
+
+---
+
+## Implementation Units
+
+### U1. Stretch status surface and unlock contract
+
+- **Goal:** Give operators a durable stretch status home and a hard crop→full unlock token scoped by field set, without touching Phase 1 CLOSED language.
+- **Requirements:** R3, R7, R8, R9, R10; AE3, AE4; KTD4, KTD5, KTD6
+- **Dependencies:** None
+- **Files:**
+  - Modify: `docs/reference/core/EXACT_PROOF_FINDINGS.md` (stretch subsection / link only; do not rewrite ONE TRUTH CLOSED)
+  - Modify: `.claude/HANDOFF.md` (stretch operator notes)
+  - Create: helpers under `slavv_python/analytics/parity/proof/` for unlock token + status enum serialization (prefer thin helpers over a new `parity/stretch/` package unless a second consumer appears)
+  - Create: `tests/unit/parity/test_stretch_unlock_gate.py`
+- **Approach:**
+  1. Define status values covering KTD5 failure classes plus progress states (`crop_energy_passed`, etc.); keep one authoritative enum shared with docs.
+  2. Persist a crop unlock artifact naming field set (`energy` vs `energy+discrete`) and dest run pairing.
+  3. Gate full stretch entry on unlock presence; refuse otherwise (AE3).
+  4. Document that stretch greens never edit ONE TRUTH CLOSED (AE4); `stretch_complete` requires Energy+discrete at full.
+- **Execution note:** Characterization-first on refuse paths; no Energy math in this unit.
+- **Patterns to follow:** `load_proof_record` / dest pairing discipline; parity experiment hygiene (new roots only).
+- **Test scenarios:**
+  - Covers AE3. Full stretch entry without unlock → refuse / incomplete process.
+  - Unlock for Energy-only does not authorize Network discrete full claim.
+  - Covers AE4. Status writer does not mutate ONE TRUTH CLOSED strings.
+  - Infra-labeled failure is not recorded as `blocked_float_path`.
+- **Verification:** Unit tests green; docs show stretch separate from Phase 1 CLOSED.
+
+### U2. MATLAB-engine Energy float adapter
+
+- **Goal:** Provide an in-process MATLAB engine session adapter usable by exact-route Energy float math, with clear infra failure modes.
+- **Requirements:** R4, R6; KTD2, KTD3; ASSUME4
+- **Dependencies:** None (can parallel U1)
+- **Files:**
+  - Create: `slavv_python/pipeline/energy/matlab_engine_backend.py` (or similarly named thin module; keep under 1000 lines)
+  - Create: MATLAB helper under `external/Vectorization-Public/` or `workspace/scratch/matlab/` only if needed for path-add during stretch (prefer vendored source path)
+  - Create: `tests/unit/pipeline/energy/test_matlab_engine_backend.py`
+  - Optionally extend: `tests/support/random_component_parity.py` for shared MATLAB discovery only
+- **Approach:**
+  1. Start one engine per Energy job; `addpath` once; quit at job end.
+  2. Convert arrays with Fortran-order / `matlab.double` buffer path; forbid `.tolist()` for volume transfers.
+  3. Expose a narrow call surface for float-sensitive Energy (filter/FFT/octave body) — expand only as crop evidence demands.
+  4. Missing MATLAB / version / license → `incomplete_infra`, not R3.
+  5. Do not treat MATLAB writing the full Energy artifact alone as success (R6).
+- **Execution note:** Tests skip cleanly when MATLAB/engine unavailable.
+- **Patterns to follow:** Random-component MATLAB prerequisite discovery; AGENTS.md float64 + `[Y,X,Z]` rules.
+- **Test scenarios:**
+  - Engine missing → infra error / skip, not silent NumPy fallback for stretch origin.
+  - Happy path: small array round-trip preserves float64 values and axis order policy.
+  - `nargout` / path-miss failures surface as infra, not bit-equal pass.
+  - Covers R6. Adapter does not offer “load MATLAB-only energy checkpoint as stretch success.”
+- **Verification:** Unit tests pass or skip; no change to default Energy origin.
+
+### U3. Exact-route Energy dispatch to engine float path
+
+- **Goal:** Wire exact-route Energy so stretch runs can produce engine-backed Energy while Python owns orchestration, resume lattice, and checkpoint packaging.
+- **Requirements:** R1, R4, R6; KD3; KTD2, KTD3, KTD7; ASSUME5, ASSUME6
+- **Dependencies:** U2
+- **Files:**
+  - Modify: `slavv_python/pipeline/energy/manager.py`
+  - Modify: `slavv_python/pipeline/energy/resumable.py` (origin stamp on resume writers — required)
+  - Modify: `slavv_python/pipeline/energy/chunking.py` if `_energy_result_payload` stamps origin
+  - Modify: `slavv_python/pipeline/energy/matlab_get_energy_v202_chunked.py` and/or `matlab_energy_filter_v200.py` (thin dispatch only; avoid file bloat)
+  - Modify: `slavv_python/pipeline/energy/provenance.py` (whitelist stretch origin for stretch mode only)
+  - Modify: `slavv_python/pipeline/edges/discovery.py` — stretch-aware Exact-Route Watershed allow predicate without silently widening Phase 1 `EXACT_COMPATIBLE_ENERGY_ORIGINS`
+  - Modify: `slavv_python/utils/validation.py` and/or `slavv_python/pipeline/energy/config.py` for a dedicated params flag (e.g. `energy_float_backend=matlab_engine`), not a bare new `energy_method` value
+  - Create/Modify: tests under `tests/unit/pipeline/energy/` for origin stamp + dispatch
+  - Create: `tests/unit/pipeline/energy/test_stretch_energy_origin.py`
+- **Approach:**
+  1. Add dedicated stretch float-backend flag selecting engine path without changing Phase 1 default `python_native_hessian` / `energy_method=hessian`.
+  2. Stamp checkpoints with the new origin in manager **and** resumable writers; refuse mixed NumPy/engine Energy for stretch proofs.
+  3. Keep Watershed Discovery on Exact Route under stretch by a stretch-mode allow path that does not blur Phase 1 provenance (document the chosen origin string).
+  4. Keep chunk/resume ownership in Python; call MATLAB for float-sensitive body per KTD3.
+  5. Default stretch writers: `n_jobs=1` until bit-identity with parallel merge is proven.
+- **Execution note:** Prefer a failing crop `--strict-floats` Energy compare (NumPy path) as characterization before flipping origin.
+- **Patterns to follow:** Exact-route float64 path in `EnergyManager`; provenance allowlist pattern.
+- **Test scenarios:**
+  - Default exact path origin unchanged (`python_native_hessian`).
+  - Stretch origin selected → adapter invoked; checkpoint stamped.
+  - Mixed-origin Energy rejected by stretch proof helper.
+  - Covers AE1. NumPy-only Energy still fails `--strict-floats` on crop fixtures where ULP drift is expected.
+- **Verification:** Unit/integration tests; Phase 1 default Energy path behavior unchanged.
+
+### U4. Crop Energy zero-tolerance proof and unlock
+
+- **Goal:** Prove crop Energy bit-equal under the engine path and emit the Energy field-set unlock for F2.
+- **Requirements:** R1, R3, R4, R7; F1; AE1, AE2; KTD1, KTD4, KTD6
+- **Dependencies:** U1, U3
+- **Files:**
+  - Modify: `slavv_python/analytics/parity/proof/coordinator.py`, `cli_handlers/cli_proofs.py` — emit Energy unlock on `--strict-floats` green; do not change ADR 0011 defaults
+  - Modify: unlock helpers from U1
+  - Create: `tests/unit/parity/test_stretch_crop_energy_strict_floats.py`
+  - Docs: stretch run recipe pointing at `crop_M_exact_v3` / `180709_E_crop_M_v2` surfaces
+- **Approach:**
+  1. Run crop Energy via stretch origin; compare with `prove-exact --stage energy --strict-floats`.
+  2. On green, write Energy unlock token for that dest/oracle pairing from the prove path.
+  3. On red after engine path, record `blocked_float_path` (or continue deepening MATLAB surface) — never report ADR 0011 allclose as stretch success.
+  4. New dest run root only.
+- **Execution note:** Smoke/runtime on operator host with MATLAB; unit-test the gate wiring with fixtures.
+- **Patterns to follow:** Existing `--strict-floats` / `EnergyFloatGateOptions`; PARITY_PRE_GATE crop surfaces.
+- **Test scenarios:**
+  - Covers AE1. Fixture with ULP drift fails strict Energy gate.
+  - Covers AE2. Engine-stamped equal arrays pass strict Energy gate and emit unlock.
+  - Allclose-green + strict-red must not emit unlock.
+- **Verification:** Crop Energy `--strict-floats` green on harness host; unlock artifact present; ONE TRUTH CLOSED untouched.
+
+### U5. Discrete strict-field stretch on crop
+
+- **Goal:** Bring exact `connections` / order-sensitive emission into the same zero-tolerance bar on crop after Energy floats are unlocked.
+- **Requirements:** R1, R2; F1; KTD5; ASSUME1
+- **Dependencies:** U4
+- **Files:**
+  - Modify: `slavv_python/analytics/parity/proof/artifact_comparator.py` plus CLI (`commands.py` / `cli_proofs.py`) for an explicit stretch discrete mode (strict `connections` / order equality), separate from ADR 0012 ownership/multiset ship bars
+  - Create: `tests/unit/parity/test_stretch_discrete_strict_field.py`
+  - Docs: stretch status for `incomplete_discrete`
+- **Approach:**
+  1. After Energy unlock, run crop edges/network under the **stretch discrete** compare mode (not ADR 0012 green alone; `prove-exact-sequence` alone does not unlock discrete).
+  2. Failure → `incomplete_discrete` (not R3).
+  3. Success → expand unlock field set to include discrete (required before `stretch_complete`).
+- **Execution note:** Do not reopen ADR 0012 ship bars; this is stretch-only strict-field.
+- **Patterns to follow:** `prove-exact-sequence` / strict connections fallback diagnostics; ADR 0012 addenda for stretch vs ship.
+- **Test scenarios:**
+  - Energy unlock present + connections mismatch → `incomplete_discrete`, unlock not expanded.
+  - Exact connections match → discrete field set added to unlock.
+  - ADR 0012 ownership-map green alone does not mark discrete stretch complete.
+- **Verification:** Crop discrete status correctly classified; Phase 1 ADR 0012 evaluated ship path unchanged.
+
+### U6. Full `180709_E` zero-tolerance after unlock
+
+- **Goal:** Run full-volume stretch proof only after crop unlock for the same field set; record complete or incomplete-at-full without Phase 1 reopen.
+- **Requirements:** R1, R8, R9, R10; F2; AE3, AE4; KTD4, KTD6
+- **Dependencies:** U4 (Energy-only full) or U5 (full discrete)
+- **Files:**
+  - Modify: `slavv_python/analytics/parity/cli_handlers/cli_runs.py` and/or stretch prove wrapper — refuse full stretch launch/prove without matching unlock (AE3)
+  - Modify: unlock helpers from U1; status writer for `incomplete_at_full` / `stretch_complete`
+  - Create: `tests/unit/parity/test_stretch_full_volume_gate.py`
+  - Docs: full stretch run root recipe vs `canonical_full_v18`
+- **Approach:**
+  1. Refuse full stretch without matching unlock (AE3) at launch/prove entry — not checklist-only.
+  2. New full stretch dest root; carry Energy/Vertices as policy allows; never overwrite claim root.
+  3. Prove unlocked field set under `--strict-floats` (Energy-only progress allowed; `stretch_complete` only when discrete unlock + full discrete also green).
+  4. Update stretch status only.
+- **Execution note:** Operator-host long run; unit-test gate and status transitions with fixtures.
+- **Patterns to follow:** Claim run root policy; orientation lessons from resume-energy-orientation; high-octave divergence note.
+- **Test scenarios:**
+  - Covers AE3. Full entry without unlock refused.
+  - Energy-only unlock + attempt full discrete claim refused.
+  - Covers AE4. Completing stretch status does not flip ONE TRUTH CLOSED.
+- **Verification:** Gate tests green; on host, full proof only after unlock; status surface correct.
+
+### U7. Optional MKL falsifying spike
+
+- **Goal:** Provide a short optional spike that can falsify “in-process MKL alone yields bit-equal Energy,” without replacing Approach A.
+- **Requirements:** R5; KTD8
+- **Dependencies:** None (optional; must not block U2–U6)
+- **Files:**
+  - Create: spike notes under `workspace/scratch/` or a short script under `scripts/` if retained
+  - Create: `tests/unit/parity/test_mkl_spike_does_not_replace_engine.py` (policy/status assertion)
+- **Approach:**
+  1. If run, document result as falsifier evidence only.
+  2. Bit-equal MKL crop must not set Approach A complete or emit stretch-complete without scope change.
+- **Test scenarios:**
+  - Covers R5. Status/policy helper rejects “MKL pass ⇒ stretch complete.”
+- **Verification:** Policy test green; spike artifacts clearly labeled non-canonical.
+
+---
+
+## Verification Contract
+
+- **Unit / integration (default CI):** `python -m pytest` on new stretch unlock, origin, and gate tests; engine tests skip without MATLAB.
+- **Quality:** `ruff` + `mypy` on touched packages; respect 1000-line file limit.
+- **Stretch Energy gate (operator host):** crop `prove-exact --stage energy --strict-floats` against crop oracle after engine path; unlock must emit only on strict green.
+- **Stretch discrete (after Energy):** crop strict-field / sequence surfaces; classify `incomplete_discrete` distinctly.
+- **Full stretch:** refused without unlock; after unlock, same `--strict-floats` field set on new full dest root — never on `canonical_full_v18`.
+- **Non-goals for verification:** ADR 0011 default allclose green is **not** stretch success; ADR 0012 ownership-map green alone is **not** discrete stretch complete; `prove-energy-ulp` remains advisory telemetry.
+
+---
+
+## Definition of Done
+
+**Global**
+
+- [ ] Crop Energy bit-equal under engine path with `--strict-floats`, or program explicitly `blocked_float_path` / `incomplete_infra` (not allclose success).
+- [ ] Discrete crop + full under R2 green before `stretch_complete` (Energy-only full is intermediate progress only).
+- [ ] Full stretch only after matching unlock; AE3 enforced in launch/prove code.
+- [ ] Phase 1 ONE TRUTH remains CLOSED on `canonical_full_v18`; stretch status recorded separately (AE4).
+- [ ] Abandoned spike/experiment code removed from production package; scratch left under `workspace/scratch/`.
+- [ ] Unit tests for gates/status/origin land under `tests/` per `tests/README.md`.
+
+**Per unit**
+
+- U1: Unlock + status tests green; docs separated from Phase 1 CLOSED.
+- U2: Adapter tests pass/skip; no silent NumPy fallback for stretch origin.
+- U3: Provenance stamp + default path unchanged.
+- U4: Crop Energy strict green ⇒ unlock; allclose≠unlock.
+- U5: Discrete failures labeled `incomplete_discrete`.
+- U6: Full gate refuses without unlock; status updates stretch only.
+- U7: Optional; if present, cannot mark Approach A complete alone.
+
+---
+
+## Appendix
+
+### Sources & Research
+
+- Product contract origin: this file (ce-brainstorm requirements-only enrichment).
+- `docs/adr/0011-energy-float-certification-policy.md` — allclose ship vs Option A/D bit-identical / MATLAB-linked path.
+- `docs/adr/0010-random-component-parity-suite.md` — ≥1 ULP IFFT floor NumPy vs MATLAB MKL.
+- `docs/adr/0012-edge-watershed-parity-bar.md` — ship vs strict-field stretch.
+- `docs/adr/0009-parity-pre-gate-tiers.md` — crop → canonical ladder.
+- `docs/reference/core/EXACT_PROOF_FINDINGS.md` — Phase 1 CLOSED on `canonical_full_v18`.
+- `docs/solutions/parity/canonical-energy-high-octave-divergence.md` — crop≠full Energy lessons.
+- `docs/solutions/parity/resume-energy-orientation.md` — full-volume orientation pitfall.
+- `docs/solutions/parity/exact-energy-chunk-parallelism.md` — `n_jobs` bit-identity and ETA pitfalls.
+- `docs/solutions/best-practices/parity-experiment-hygiene.md` — cheap loop + new run roots.
+- Code anchors: `slavv_python/pipeline/energy/manager.py`, `matlab_energy_filter_v200.py`, `matlab_get_energy_v202_chunked.py`, `provenance.py`; `slavv_python/analytics/parity/proof/energy_ulp_proof.py`, `coordinator.py`, `commands.py` (`--strict-floats`); `tests/support/random_component_parity.py` (batch MATLAB only).
+- External (load-bearing for KTD3): MathWorks MATLAB Engine for Python — start/reuse engine, `matlab.double` / column-major, large-array transfer cost pre-R2022a.
+
+### Must-read before implementation
+
+1. `docs/adr/0011-energy-float-certification-policy.md`
+2. `docs/adr/0010-random-component-parity-suite.md`
+3. `docs/solutions/parity/canonical-energy-high-octave-divergence.md`
+4. `docs/solutions/best-practices/parity-experiment-hygiene.md`

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -67,7 +67,7 @@ This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-e
 
 Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
 
-**Session status (2026-08-14):** Foundation landed (unlock/status, engine adapter, origin dispatch, gates). Crop Energy bit-equal is **`incomplete_infra`** on the repo Python 3.12 venv — MATLAB R2019a Engine for Python supports 2.7/3.5/3.6/3.7 only. Not redefined as ADR 0011 allclose success.
+**Session status (2026-08-14):** `energy_filter_V200` is bound behind `energy_float_backend=matlab_engine` (Python owns chunking/resume; MATLAB owns FFT+filter). Crop Energy `--strict-floats` still needs an isolated Python 3.7 interpreter with `matlab.engine` (R2019a ABI). Repo `.venv` is 3.12 and cannot host the engine in-process. Set `STRETCH_PY37_PYTHON` to the isolated 3.7 prefix and run `resume-exact-run --energy-float-backend matlab_engine`. Not redefined as ADR 0011 allclose success. Phase 1 remains CLOSED on `canonical_full_v18`.
 
 ---
 

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -67,7 +67,7 @@ This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-e
 
 Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
 
-**Session status (2026-08-15):** Crop Energy on `crop_M_stretch_engine_v1` finished via Python 3.7 + R2019a `matlab.engine` (`energy_float_backend=matlab_engine`). `prove-exact --stage energy --strict-floats` **FAIL**: 2,623,250 / 4,194,304 voxels bit-identical (62.5%); 1,571,054 not bit-identical; scale indices match; max abs delta `1e-10`; mismatch ULP p50=1, p90=4. Status is **`blocked_float_path`** (engine path ran; floats are not bit-equal). Not allclose success; no unlock token. Phase 1 remains CLOSED on `canonical_full_v18`. Proof: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v1/03_Analysis/exact_proof_energy.json`.
+**Session status (2026-08-15):** Crop Energy on `crop_M_stretch_engine_v1` finished via Python 3.7 + R2019a `matlab.engine`. `prove-exact --stage energy --strict-floats` **FAIL**: 2,623,250 / 4,194,304 voxels bit-identical (62.5%); scale indices match; max abs delta `1e-10`; mismatch ULP p50=1. Status **`blocked_float_path`** (not allclose success; no unlock). Remaining ULP is Python `interp3` after MATLAB `energy_filter_V200`. Next dest: `crop_M_stretch_engine_v2` with MATLAB `interp3` + scale-min in `stretch_energy_chunk_v202`. Do not start U5/U6 without Energy unlock. Phase 1 remains CLOSED on `canonical_full_v18`. Proof: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v1/03_Analysis/exact_proof_energy.json`.
 
 ---
 

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -52,6 +52,23 @@
 
 ---
 
+## True zero-tolerance stretch (separate from Phase 1)
+
+> **Phase 1 Certification remains CLOSED** on `canonical_full_v18` (see [ONE TRUTH](#one-truth--phase-1-parity-validated-from-disk)). Stretch greens/reds **never** rewrite that answer or ADR 0011/0012 ship bars.
+
+This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-equal Energy floats + discrete strict fields under `--strict-floats`). Plan: [2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md](../../plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md). Helpers: `slavv_python.analytics.parity.proof.stretch`.
+
+| Concept | Rule |
+| :--- | :--- |
+| Compare gate | `prove-exact --strict-floats` only; default allclose is **not** stretch success |
+| Crop → full | Hard unlock token (`stretch_crop_unlock.json`) scoped by field set (`energy` vs `energy+discrete`) |
+| Status taxonomy | `blocked_float_path` / `incomplete_discrete` / `incomplete_infra` / `incomplete_at_full` / `stretch_complete` (Energy **and** discrete at full) |
+| Dest roots | New stretch run roots only — never overwrite `canonical_full_v18` |
+
+Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
+
+---
+
 ## Audit inventory (folders, not a second verdict)
 
 Pass/fail is only in [ONE TRUTH](#one-truth--phase-1-parity-validated-from-disk). This table says which folders exist and what they are for.

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -67,7 +67,7 @@ This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-e
 
 Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
 
-**Session status (2026-08-14):** `energy_filter_V200` is bound behind `energy_float_backend=matlab_engine` (Python owns chunking/resume; MATLAB owns FFT+filter). Crop Energy `--strict-floats` still needs an isolated Python 3.7 interpreter with `matlab.engine` (R2019a ABI). Repo `.venv` is 3.12 and cannot host the engine in-process. Set `STRETCH_PY37_PYTHON` to the isolated 3.7 prefix and run `resume-exact-run --energy-float-backend matlab_engine`. Not redefined as ADR 0011 allclose success. Phase 1 remains CLOSED on `canonical_full_v18`.
+**Session status (2026-08-15):** Isolated Python 3.7.16 + `matlab.engine` (R2019a) is available at `workspace/scratch/conda_py37_stretch` (`STRETCH_PY37_PYTHON`). Engine smoke on a 6³ chunk succeeded. Crop Energy writer dest is `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v1` (new root; not `crop_M_exact_v3` / `canonical_full_v18`). Crop `--strict-floats` has **not** passed yet — status is `crop_energy_running` / not `crop_energy_passed`. Default allclose is not stretch success. Phase 1 remains CLOSED on `canonical_full_v18`.
 
 ---
 

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -67,7 +67,7 @@ This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-e
 
 Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
 
-**Session status (2026-08-15):** Isolated Python 3.7.16 + `matlab.engine` (R2019a) is available at `workspace/scratch/conda_py37_stretch` (`STRETCH_PY37_PYTHON`). Engine smoke on a 6³ chunk succeeded. Crop Energy writer dest is `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v1` (new root; not `crop_M_exact_v3` / `canonical_full_v18`). Crop `--strict-floats` has **not** passed yet — status is `crop_energy_running` / not `crop_energy_passed`. Default allclose is not stretch success. Phase 1 remains CLOSED on `canonical_full_v18`.
+**Session status (2026-08-15):** Crop Energy on `crop_M_stretch_engine_v1` finished via Python 3.7 + R2019a `matlab.engine` (`energy_float_backend=matlab_engine`). `prove-exact --stage energy --strict-floats` **FAIL**: 2,623,250 / 4,194,304 voxels bit-identical (62.5%); 1,571,054 not bit-identical; scale indices match; max abs delta `1e-10`; mismatch ULP p50=1, p90=4. Status is **`blocked_float_path`** (engine path ran; floats are not bit-equal). Not allclose success; no unlock token. Phase 1 remains CLOSED on `canonical_full_v18`. Proof: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v1/03_Analysis/exact_proof_energy.json`.
 
 ---
 

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -67,6 +67,8 @@ This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-e
 
 Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
 
+**Session status (2026-08-14):** Foundation landed (unlock/status, engine adapter, origin dispatch, gates). Crop Energy bit-equal is **`incomplete_infra`** on the repo Python 3.12 venv — MATLAB R2019a Engine for Python supports 2.7/3.5/3.6/3.7 only. Not redefined as ADR 0011 allclose success.
+
 ---
 
 ## Audit inventory (folders, not a second verdict)

--- a/scripts/stretch_energy_chunk_v202.m
+++ b/scripts/stretch_energy_chunk_v202.m
@@ -1,0 +1,41 @@
+function [energy, scale_idx] = stretch_energy_chunk_v202(chunk, matching_kernel_string, radii, vessel_wall_thickness_in_microns, microns_per_pixel, pixels_per_sigma_PSF, y0, y1, x0, x1, z0, z1, y_offset, x_offset, z_offset, y_write_count, x_write_count, z_write_count, rf_y, rf_x, rf_z, gaussian_to_ideal_ratio, spherical_to_annular_ratio, scales_per_octave)
+%STRETCH_ENERGY_CHUNK_V202 MATLAB-engine per-chunk Energy float body.
+% Python still owns chunk lattice, resume, and checkpoint packaging.
+% MATLAB owns fourier_transform_V2, energy_filter_V200, interp3 upsample,
+% and min-projection across scales at this octave (get_energy_V202).
+
+chunk_dft = fourier_transform_V2(chunk);
+local_ranges = { (double(y0):double(y1)), (double(x0):double(x1)), (double(z0):double(z1)) };
+
+rf = [double(rf_y), double(rf_x), double(rf_z)];
+y_off = double(y_offset);
+x_off = double(x_offset);
+z_off = double(z_offset);
+yw = double(y_write_count);
+xw = double(x_write_count);
+zw = double(z_write_count);
+
+[mesh_Y, mesh_X, mesh_Z] = ndgrid( ...
+    linspace(1 + mod(y_off, rf(1)) / rf(1), ...
+             1 + mod(y_off, rf(1)) / rf(1) + (yw - 1) / rf(1), yw), ...
+    linspace(1 + mod(x_off, rf(2)) / rf(2), ...
+             1 + mod(x_off, rf(2)) / rf(2) + (xw - 1) / rf(2), xw), ...
+    linspace(1 + mod(z_off, rf(3)) / rf(3), ...
+             1 + mod(z_off, rf(3)) / rf(3) + (zw - 1) / rf(3), zw));
+
+radii = double(radii(:)).';
+n_scales = numel(radii);
+energy_chunk_4D = zeros([yw, xw, zw, n_scales]);
+
+for s_idx = 1:n_scales
+    energy_chunk_4D(:, :, :, s_idx) = interp3( ...
+        energy_filter_V200( ...
+            chunk_dft, matching_kernel_string, radii(s_idx), ...
+            vessel_wall_thickness_in_microns, microns_per_pixel, pixels_per_sigma_PSF, ...
+            local_ranges, gaussian_to_ideal_ratio, spherical_to_annular_ratio, scales_per_octave), ...
+        mesh_X, mesh_Y, mesh_Z);
+end
+
+[energy, scale_idx] = min(energy_chunk_4D, [], 4);
+energy(energy >= 0) = 0;
+end

--- a/scripts/stretch_energy_filter_v200.m
+++ b/scripts/stretch_energy_filter_v200.m
@@ -1,0 +1,13 @@
+function energy = stretch_energy_filter_v200(chunk, matching_kernel_string, radius_of_lumen_in_microns, vessel_wall_thickness_in_microns, microns_per_pixel, pixels_per_sigma_PSF, y0, y1, x0, x1, z0, z1, gaussian_to_ideal_ratio, spherical_to_annular_ratio, scales_per_octave)
+%STRETCH_ENERGY_FILTER_V200 MATLAB-engine Energy float body (KTD3).
+% Python owns chunking, resume, and checkpoint packaging. MATLAB owns
+% fourier_transform_V2 + energy_filter_V200. local_ranges are 1-based inclusive
+% indices into the padded FFT grid (same convention as get_energy_V202).
+
+chunk_dft = fourier_transform_V2(chunk);
+local_ranges = { (double(y0):double(y1)), (double(x0):double(x1)), (double(z0):double(z1)) };
+energy = energy_filter_V200( ...
+    chunk_dft, matching_kernel_string, radius_of_lumen_in_microns, ...
+    vessel_wall_thickness_in_microns, microns_per_pixel, pixels_per_sigma_PSF, ...
+    local_ranges, gaussian_to_ideal_ratio, spherical_to_annular_ratio, scales_per_octave);
+end

--- a/scripts/stretch_matlab_engine_worker.py
+++ b/scripts/stretch_matlab_engine_worker.py
@@ -112,6 +112,73 @@ def main():
                     _fail("energy_filter failed: %s" % exc)
                     continue
                 _ok({"out_npy": out_path})
+            elif op == "energy_chunk":
+                if engine is None:
+                    _fail("engine not started")
+                    continue
+                try:
+                    chunk = np.load(str(msg["chunk_npy"]))
+                    chunk = np.asfortranarray(np.asarray(chunk, dtype=np.float64))
+                    flat = [float(v) for v in np.ravel(chunk, order="F")]
+                    size = [int(d) for d in chunk.shape]
+                    try:
+                        ml_chunk = matlab.double(flat, size=size)
+                    except TypeError:
+                        ml_chunk = matlab.double(flat)
+                    microns = matlab.double(_as_row(msg["microns_per_pixel"]))
+                    psf = matlab.double(_as_row(msg["pixels_per_sigma_psf"]))
+                    radii = matlab.double(_as_row(msg["radii"]))
+                    energy, scale_idx = engine.stretch_energy_chunk_v202(
+                        ml_chunk,
+                        str(msg["matching_kernel_string"]),
+                        radii,
+                        float(msg["vessel_wall"]),
+                        microns,
+                        psf,
+                        float(msg["y0"]),
+                        float(msg["y1"]),
+                        float(msg["x0"]),
+                        float(msg["x1"]),
+                        float(msg["z0"]),
+                        float(msg["z1"]),
+                        float(msg["y_offset"]),
+                        float(msg["x_offset"]),
+                        float(msg["z_offset"]),
+                        float(msg["y_write_count"]),
+                        float(msg["x_write_count"]),
+                        float(msg["z_write_count"]),
+                        float(msg["rf_y"]),
+                        float(msg["rf_x"]),
+                        float(msg["rf_z"]),
+                        float(msg["gaussian_to_ideal_ratio"]),
+                        float(msg["spherical_to_annular_ratio"]),
+                        float(msg["scales_per_octave"]),
+                        nargout=2,
+                    )
+                    y_len = int(msg["y_write_count"])
+                    x_len = int(msg["x_write_count"])
+                    z_len = int(msg["z_write_count"])
+                    out_shape = (y_len, x_len, z_len)
+                    energy_data = getattr(energy, "_data", None)
+                    if energy_data is not None:
+                        energy_out = np.frombuffer(energy_data, dtype=np.float64).copy()
+                        energy_out = np.reshape(energy_out, out_shape, order="F")
+                    else:
+                        energy_out = np.asarray(energy, dtype=np.float64)
+                    scale_data = getattr(scale_idx, "_data", None)
+                    if scale_data is not None:
+                        scale_out = np.frombuffer(scale_data, dtype=np.float64).copy()
+                        scale_out = np.reshape(scale_out, out_shape, order="F")
+                    else:
+                        scale_out = np.asarray(scale_idx, dtype=np.float64)
+                    energy_path = str(msg["energy_npy"])
+                    scale_path = str(msg["scale_npy"])
+                    np.save(energy_path, np.ascontiguousarray(energy_out))
+                    np.save(scale_path, np.ascontiguousarray(scale_out))
+                except Exception as exc:
+                    _fail("energy_chunk failed: %s" % exc)
+                    continue
+                _ok({"energy_npy": energy_path, "scale_npy": scale_path})
             elif op == "quit":
                 if engine is not None:
                     try:

--- a/scripts/stretch_matlab_engine_worker.py
+++ b/scripts/stretch_matlab_engine_worker.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+"""Python 3.7 MATLAB Engine worker for stretch Energy float math.
+
+Must run under Python 3.7 (R2019a Engine ABI). Do not import slavv_python.
+Protocol: one JSON object per stdin line; one JSON object per stdout line.
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import sys
+import traceback
+
+import numpy as np
+
+
+def _fail(message):
+    print(json.dumps({"ok": False, "error": message}), flush=True)
+
+
+def _ok(payload=None):
+    body = {"ok": True}
+    if payload:
+        body.update(payload)
+    print(json.dumps(body), flush=True)
+
+
+def _as_row(values):
+    arr = np.asarray(values, dtype=np.float64).reshape(-1)
+    return arr.tolist()
+
+
+def main():
+    try:
+        import matlab
+        import matlab.engine
+    except Exception as exc:
+        _fail("matlab.engine import failed: %s" % exc)
+        return 2
+
+    engine = None
+    try:
+        for raw in sys.stdin:
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                msg = json.loads(line)
+            except ValueError as exc:
+                _fail("invalid JSON: %s" % exc)
+                continue
+            op = msg.get("op")
+            if op == "start":
+                if engine is not None:
+                    _ok()
+                    continue
+                try:
+                    engine = matlab.engine.start_matlab()
+                    engine.addpath(str(msg["vectorization_source"]), nargout=0)
+                    engine.addpath(str(msg["helper_dir"]), nargout=0)
+                except Exception as exc:
+                    engine = None
+                    _fail("start_matlab failed: %s" % exc)
+                    continue
+                _ok()
+            elif op == "energy_filter":
+                if engine is None:
+                    _fail("engine not started")
+                    continue
+                try:
+                    chunk = np.load(str(msg["chunk_npy"]))
+                    chunk = np.asfortranarray(np.asarray(chunk, dtype=np.float64))
+                    flat = [float(v) for v in np.ravel(chunk, order="F")]
+                    size = [int(d) for d in chunk.shape]
+                    try:
+                        ml_chunk = matlab.double(flat, size=size)
+                    except TypeError:
+                        ml_chunk = matlab.double(flat)
+                    microns = matlab.double(_as_row(msg["microns_per_pixel"]))
+                    psf = matlab.double(_as_row(msg["pixels_per_sigma_psf"]))
+                    energy = engine.stretch_energy_filter_v200(
+                        ml_chunk,
+                        str(msg["matching_kernel_string"]),
+                        float(msg["radius"]),
+                        float(msg["vessel_wall"]),
+                        microns,
+                        psf,
+                        float(msg["y0"]),
+                        float(msg["y1"]),
+                        float(msg["x0"]),
+                        float(msg["x1"]),
+                        float(msg["z0"]),
+                        float(msg["z1"]),
+                        float(msg["gaussian_to_ideal_ratio"]),
+                        float(msg["spherical_to_annular_ratio"]),
+                        float(msg["scales_per_octave"]),
+                        nargout=1,
+                    )
+                    y_len = int(msg["y1"]) - int(msg["y0"]) + 1
+                    x_len = int(msg["x1"]) - int(msg["x0"]) + 1
+                    z_len = int(msg["z1"]) - int(msg["z0"]) + 1
+                    data = getattr(energy, "_data", None)
+                    if data is not None:
+                        out = np.frombuffer(data, dtype=np.float64).copy()
+                        out = np.reshape(out, (y_len, x_len, z_len), order="F")
+                    else:
+                        out = np.asarray(energy, dtype=np.float64)
+                    out_path = str(msg["out_npy"])
+                    np.save(out_path, np.ascontiguousarray(out))
+                except Exception as exc:
+                    _fail("energy_filter failed: %s" % exc)
+                    continue
+                _ok({"out_npy": out_path})
+            elif op == "quit":
+                if engine is not None:
+                    try:
+                        engine.quit()
+                    except Exception:
+                        pass
+                    engine = None
+                _ok()
+                return 0
+            else:
+                _fail("unknown op: %s" % op)
+    except Exception:
+        _fail(traceback.format_exc())
+        return 1
+    finally:
+        if engine is not None:
+            try:
+                engine.quit()
+            except Exception:
+                pass
+    return 0
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+    sys.exit(main())

--- a/slavv_python/analytics/parity/cli_handlers/cli_proofs.py
+++ b/slavv_python/analytics/parity/cli_handlers/cli_proofs.py
@@ -32,6 +32,7 @@ from slavv_python.analytics.parity.proof.energy_ulp_proof import (
     persist_energy_ulp_proof_report,
 )
 from slavv_python.analytics.parity.proof.proof_report import render_exact_proof_report
+from slavv_python.analytics.parity.proof.stretch import emit_stretch_energy_unlock_if_eligible
 from slavv_python.analytics.parity.utils import (
     payload_hash,
     write_json_with_hash,
@@ -93,6 +94,24 @@ def handle_prove_exact(args: argparse.Namespace) -> None:
 
     if report.get("stage_summaries"):
         print(render_exact_proof_report(report))
+
+    strict_floats = bool(getattr(args, "strict_floats", False))
+    if (
+        strict_floats
+        and report.get("passed")
+        and oracle_root is not None
+        and json_path is not None
+        and stage_arg in {"energy", "all"}
+    ):
+        unlock = emit_stretch_energy_unlock_if_eligible(
+            dest_run_root=dest_run_root,
+            oracle_root=oracle_root,
+            proof_path=json_path,
+            report=report,
+            strict_floats=True,
+        )
+        if unlock is not None:
+            print(f"stretch Energy unlock: {unlock}")
 
     if not report.get("passed"):
         sys.exit(1)

--- a/slavv_python/analytics/parity/cli_handlers/cli_runs.py
+++ b/slavv_python/analytics/parity/cli_handlers/cli_runs.py
@@ -47,6 +47,11 @@ from slavv_python.analytics.parity.proof.reports import (
     persist_recording_tables,
     render_experiment_summary,
 )
+from slavv_python.analytics.parity.proof.stretch import (
+    UNLOCK_FILENAME,
+    StretchFieldSet,
+    gate_full_stretch_entry,
+)
 from slavv_python.analytics.parity.runs.bootstrap import (
     _copy_exact_bootstrap_refs,
     _finalize_init_exact_run,
@@ -81,6 +86,37 @@ from slavv_python.storage import load_tiff_volume
 
 if TYPE_CHECKING:
     import argparse
+
+
+def _enforce_stretch_full_unlock_gate(args: argparse.Namespace) -> None:
+    """Refuse full-volume stretch launch without a matching crop unlock (AE3)."""
+    if not bool(getattr(args, "stretch_zero_tolerance", False)):
+        return
+    dest_run_root = Path(args.dest_run_root).expanduser().resolve()
+    oracle_root = getattr(args, "oracle_root", None)
+    if oracle_root is None:
+        raise SystemExit("stretch full launch requires --oracle-root paired with crop unlock")
+    field_raw = str(getattr(args, "stretch_field_set", "energy"))
+    try:
+        field_set = StretchFieldSet(field_raw)
+    except ValueError as exc:
+        raise SystemExit("stretch_field_set must be 'energy' or 'energy+discrete'") from exc
+    unlock_arg = getattr(args, "stretch_unlock", None)
+    unlock_path = (
+        Path(unlock_arg).expanduser().resolve() if unlock_arg else dest_run_root / UNLOCK_FILENAME
+    )
+    # Prefer unlock beside dest; operators may also point at crop dest unlock.
+    crop_unlock = getattr(args, "stretch_crop_unlock", None)
+    if crop_unlock:
+        unlock_path = Path(crop_unlock).expanduser().resolve()
+    decision = gate_full_stretch_entry(
+        unlock_path=unlock_path,
+        requested_field_set=field_set,
+        dest_run_root=dest_run_root,
+        oracle_root=Path(oracle_root).expanduser().resolve(),
+    )
+    if not decision.allowed:
+        raise SystemExit(f"stretch full refused: {decision.reason}")
 
 
 def handle_rerun_python(args: argparse.Namespace) -> None:
@@ -217,6 +253,7 @@ def handle_resume_exact_run(args: argparse.Namespace) -> None:
 
 def handle_launch_exact_run(args: argparse.Namespace) -> None:
     """Launch an exact-route resume as a detached parity job."""
+    _enforce_stretch_full_unlock_gate(args)
     dest_run_root = Path(args.dest_run_root)
     try:
         manifest = launch_writer_session(

--- a/slavv_python/analytics/parity/cli_handlers/cli_runs.py
+++ b/slavv_python/analytics/parity/cli_handlers/cli_runs.py
@@ -269,6 +269,7 @@ def handle_launch_exact_run(args: argparse.Namespace) -> None:
             skip_preflight=bool(getattr(args, "skip_preflight", False)),
             skip_foreground_probe=bool(getattr(args, "skip_foreground_probe", False)),
             n_jobs=int(args.n_jobs) if getattr(args, "n_jobs", None) is not None else None,
+            energy_float_backend=getattr(args, "energy_float_backend", None),
             monitor=bool(getattr(args, "monitor", False)),
         )
     except LaunchPreparationError as exc:

--- a/slavv_python/analytics/parity/cli_handlers/cli_runs.py
+++ b/slavv_python/analytics/parity/cli_handlers/cli_runs.py
@@ -246,6 +246,7 @@ def handle_resume_exact_run(args: argparse.Namespace) -> None:
             force=bool(args.force),
             skip_preflight=bool(getattr(args, "skip_preflight", False)),
             n_jobs=int(args.n_jobs) if getattr(args, "n_jobs", None) is not None else None,
+            energy_float_backend=getattr(args, "energy_float_backend", None),
         )
 
     print(str(dest_run_root))

--- a/slavv_python/analytics/parity/commands.py
+++ b/slavv_python/analytics/parity/commands.py
@@ -284,6 +284,21 @@ PARITY_COMMAND_SPECS: tuple[CommandSpec, ...] = (
             arg("--n-jobs", type=int),
             arg("--monitor", action="store_true", help="Monitor job and send notifications"),
             arg("--force-kill", action="store_true", help="Kill active writer if exists"),
+            arg(
+                "--stretch-zero-tolerance",
+                action="store_true",
+                help="Stretch full launch: require crop unlock (does not reopen Phase 1).",
+            ),
+            arg(
+                "--stretch-field-set",
+                choices=("energy", "energy+discrete"),
+                default="energy",
+                help="Field set the crop unlock must authorize for stretch full.",
+            ),
+            arg(
+                "--stretch-crop-unlock",
+                help="Path to stretch_crop_unlock.json from a green crop --strict-floats proof.",
+            ),
         ),
         help="Launch resume-exact-run in a detached OS-owned process.",
     ),

--- a/slavv_python/analytics/parity/commands.py
+++ b/slavv_python/analytics/parity/commands.py
@@ -287,6 +287,11 @@ PARITY_COMMAND_SPECS: tuple[CommandSpec, ...] = (
                 help="Skip the preprocess-only foreground launch probe before detaching.",
             ),
             arg("--n-jobs", type=int),
+            arg(
+                "--energy-float-backend",
+                choices=("numpy", "matlab_engine"),
+                help="Stretch Energy float path (matlab_engine binds energy_filter_V200).",
+            ),
             arg("--monitor", action="store_true", help="Monitor job and send notifications"),
             arg("--force-kill", action="store_true", help="Kill active writer if exists"),
             arg(

--- a/slavv_python/analytics/parity/commands.py
+++ b/slavv_python/analytics/parity/commands.py
@@ -259,6 +259,11 @@ PARITY_COMMAND_SPECS: tuple[CommandSpec, ...] = (
             arg("--force", action="store_true"),
             arg("--skip-preflight", action="store_true"),
             arg("--n-jobs", type=int),
+            arg(
+                "--energy-float-backend",
+                choices=("numpy", "matlab_engine"),
+                help="Stretch Energy float path (matlab_engine binds energy_filter_V200).",
+            ),
             arg("--monitor", action="store_true", help="Monitor job and send notifications"),
             arg("--force-kill", action="store_true", help="Kill active writer if exists"),
         ),

--- a/slavv_python/analytics/parity/proof/stretch.py
+++ b/slavv_python/analytics/parity/proof/stretch.py
@@ -186,8 +186,7 @@ def gate_full_stretch_entry(
             allowed=False,
             status=StretchStatus.FULL_REFUSED,
             reason=(
-                f"refusing stretch dest that overwrites Phase 1 claim root "
-                f"{PHASE1_CLAIM_RUN_NAME}"
+                f"refusing stretch dest that overwrites Phase 1 claim root {PHASE1_CLAIM_RUN_NAME}"
             ),
         )
 
@@ -277,3 +276,88 @@ def mkl_spike_cannot_complete_stretch(*, mkl_bit_equal: bool) -> bool:
     """Policy: an MKL falsifier pass alone never means Approach A / stretch complete."""
     del mkl_bit_equal
     return True
+
+
+def emit_stretch_energy_unlock_if_eligible(
+    *,
+    dest_run_root: Path,
+    oracle_root: Path,
+    proof_path: Path,
+    report: dict[str, Any],
+    strict_floats: bool,
+    unlock_path: Path | None = None,
+) -> Path | None:
+    """Write Energy unlock only when ``--strict-floats`` Energy proof is green.
+
+    Allclose-only greens must not emit an unlock (AE1/AE2).
+    """
+    if not strict_floats:
+        return None
+    if not bool(report.get("passed")):
+        return None
+    energy_gate = report.get("energy_float_gate")
+    if isinstance(energy_gate, dict) and not bool(energy_gate.get("passed", True)):
+        return None
+    # Require Energy among selected stages when summaries exist.
+    summaries = report.get("stage_summaries")
+    if (
+        isinstance(summaries, dict)
+        and "energy" in summaries
+        and not bool(summaries["energy"].get("passed", False))
+    ):
+        return None
+    path = Path(unlock_path) if unlock_path else Path(dest_run_root) / UNLOCK_FILENAME
+    write_stretch_unlock(
+        path,
+        field_set=StretchFieldSet.ENERGY,
+        dest_run_root=dest_run_root,
+        oracle_root=oracle_root,
+        proof_path=proof_path,
+        strict_floats=True,
+    )
+    write_stretch_status(
+        Path(dest_run_root) / STATUS_FILENAME,
+        status=StretchStatus.CROP_ENERGY_PASSED,
+        note="crop Energy --strict-floats green; Energy unlock emitted",
+    )
+    return path
+
+
+def evaluate_stretch_discrete_connections(
+    *,
+    matlab_connections: Any,
+    python_connections: Any,
+    energy_unlock_present: bool,
+) -> ClassifiedStretchFailure | StretchStatus:
+    """Classify crop discrete strict-field result (does not change ADR 0012)."""
+    if not energy_unlock_present:
+        return classify_stretch_failure(
+            StretchFailureClass.DISCRETE,
+            detail="discrete stretch requires Energy unlock first",
+        )
+    matlab_arr = list(matlab_connections) if matlab_connections is not None else []
+    python_arr = list(python_connections) if python_connections is not None else []
+    if matlab_arr == python_arr:
+        return StretchStatus.STRETCH_COMPLETE  # local crop discrete green signal
+    return classify_stretch_failure(
+        StretchFailureClass.DISCRETE,
+        detail="connections / order mismatch under stretch discrete mode",
+    )
+
+
+def expand_unlock_with_discrete(
+    unlock_path: Path,
+    *,
+    dest_run_root: Path,
+    oracle_root: Path,
+    proof_path: Path,
+) -> StretchUnlockToken:
+    """Expand an Energy unlock to Energy+discrete after crop discrete green."""
+    return write_stretch_unlock(
+        unlock_path,
+        field_set=StretchFieldSet.ENERGY_AND_DISCRETE,
+        dest_run_root=dest_run_root,
+        oracle_root=oracle_root,
+        proof_path=proof_path,
+        strict_floats=True,
+    )

--- a/slavv_python/analytics/parity/proof/stretch.py
+++ b/slavv_python/analytics/parity/proof/stretch.py
@@ -1,0 +1,279 @@
+"""True zero-tolerance stretch status and crop→full unlock helpers.
+
+Phase 1 Certification (ONE TRUTH CLOSED) is unchanged by this module.
+Stretch proofs use ``--strict-floats`` and a hard unlock token; never rewrite
+ADR 0011/0012 ship bars or ONE TRUTH CLOSED language.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class StretchStatus(str, Enum):
+    """Authoritative stretch progress / failure taxonomy (KTD5)."""
+
+    STRETCH_NOT_STARTED = "stretch_not_started"
+    FLOAT_PATH_BUILDING = "float_path_building"
+    INCOMPLETE_INFRA = "incomplete_infra"
+    CROP_ENERGY_RUNNING = "crop_energy_running"
+    BLOCKED_FLOAT_PATH = "blocked_float_path"
+    CROP_ENERGY_PASSED = "crop_energy_passed"
+    INCOMPLETE_DISCRETE = "incomplete_discrete"
+    FULL_REFUSED = "full_refused"
+    FULL_RUNNING = "full_running"
+    INCOMPLETE_AT_FULL = "incomplete_at_full"
+    STRETCH_COMPLETE = "stretch_complete"
+
+
+class StretchFieldSet(str, Enum):
+    """Field set named by a crop unlock token."""
+
+    ENERGY = "energy"
+    ENERGY_AND_DISCRETE = "energy+discrete"
+
+
+class StretchFailureClass(str, Enum):
+    """Operator-facing failure class before status mapping."""
+
+    INFRA = "infra"
+    FLOAT_PATH = "float_path"
+    DISCRETE = "discrete"
+    AT_FULL = "at_full"
+
+
+UNLOCK_SCHEMA_VERSION = 1
+STATUS_SCHEMA_VERSION = 1
+UNLOCK_FILENAME = "stretch_crop_unlock.json"
+STATUS_FILENAME = "stretch_status.json"
+
+# Claim root must never be overwritten by stretch writers (KTD6).
+PHASE1_CLAIM_RUN_NAME = "canonical_full_v18"
+
+
+@dataclass(frozen=True)
+class StretchUnlockToken:
+    """Crop unlock authorizing full stretch for a matching field set."""
+
+    schema_version: int
+    field_set: StretchFieldSet
+    crop_dest_run_root: str
+    oracle_root: str
+    proof_path: str
+    strict_floats: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "field_set": self.field_set.value,
+            "crop_dest_run_root": self.crop_dest_run_root,
+            "oracle_root": self.oracle_root,
+            "proof_path": self.proof_path,
+            "strict_floats": self.strict_floats,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> StretchUnlockToken:
+        return cls(
+            schema_version=int(payload["schema_version"]),
+            field_set=StretchFieldSet(str(payload["field_set"])),
+            crop_dest_run_root=str(payload["crop_dest_run_root"]),
+            oracle_root=str(payload["oracle_root"]),
+            proof_path=str(payload["proof_path"]),
+            strict_floats=bool(payload.get("strict_floats", True)),
+        )
+
+
+@dataclass(frozen=True)
+class StretchGateDecision:
+    """Result of gating full-volume stretch entry."""
+
+    allowed: bool
+    status: StretchStatus
+    reason: str
+
+
+@dataclass(frozen=True)
+class ClassifiedStretchFailure:
+    """Mapped failure class → stretch status (never conflates infra with R3)."""
+
+    status: StretchStatus
+    failure_class: StretchFailureClass
+    detail: str
+
+
+def classify_stretch_failure(
+    failure_class: StretchFailureClass,
+    *,
+    detail: str,
+) -> ClassifiedStretchFailure:
+    """Map a failure class to status; infra never becomes ``blocked_float_path``."""
+    mapping = {
+        StretchFailureClass.INFRA: StretchStatus.INCOMPLETE_INFRA,
+        StretchFailureClass.FLOAT_PATH: StretchStatus.BLOCKED_FLOAT_PATH,
+        StretchFailureClass.DISCRETE: StretchStatus.INCOMPLETE_DISCRETE,
+        StretchFailureClass.AT_FULL: StretchStatus.INCOMPLETE_AT_FULL,
+    }
+    return ClassifiedStretchFailure(
+        status=mapping[failure_class],
+        failure_class=failure_class,
+        detail=detail,
+    )
+
+
+def field_set_covers(have: StretchFieldSet, need: StretchFieldSet) -> bool:
+    """Return True when ``have`` authorizes the requested ``need`` field set."""
+    if need == StretchFieldSet.ENERGY:
+        return have in {
+            StretchFieldSet.ENERGY,
+            StretchFieldSet.ENERGY_AND_DISCRETE,
+        }
+    return have == StretchFieldSet.ENERGY_AND_DISCRETE
+
+
+def write_stretch_unlock(
+    path: Path,
+    *,
+    field_set: StretchFieldSet,
+    dest_run_root: Path,
+    oracle_root: Path,
+    proof_path: Path,
+    strict_floats: bool = True,
+) -> StretchUnlockToken:
+    """Persist a crop unlock artifact (Energy or Energy+discrete)."""
+    if not strict_floats:
+        raise ValueError("stretch unlock requires strict_floats=True")
+    token = StretchUnlockToken(
+        schema_version=UNLOCK_SCHEMA_VERSION,
+        field_set=field_set,
+        crop_dest_run_root=str(Path(dest_run_root).resolve()),
+        oracle_root=str(Path(oracle_root).resolve()),
+        proof_path=str(Path(proof_path).resolve()),
+        strict_floats=True,
+    )
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(token.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return token
+
+
+def load_stretch_unlock(path: Path) -> StretchUnlockToken:
+    """Load a crop unlock token from disk."""
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"stretch unlock must be a JSON object: {path}")
+    return StretchUnlockToken.from_dict(payload)
+
+
+def gate_full_stretch_entry(
+    *,
+    unlock_path: Path,
+    requested_field_set: StretchFieldSet,
+    dest_run_root: Path,
+    oracle_root: Path,
+) -> StretchGateDecision:
+    """Refuse full stretch unless unlock exists for the same field set / oracle."""
+    dest = Path(dest_run_root)
+    if dest.name == PHASE1_CLAIM_RUN_NAME or PHASE1_CLAIM_RUN_NAME in dest.parts:
+        return StretchGateDecision(
+            allowed=False,
+            status=StretchStatus.FULL_REFUSED,
+            reason=(
+                f"refusing stretch dest that overwrites Phase 1 claim root "
+                f"{PHASE1_CLAIM_RUN_NAME}"
+            ),
+        )
+
+    path = Path(unlock_path)
+    if not path.is_file():
+        return StretchGateDecision(
+            allowed=False,
+            status=StretchStatus.FULL_REFUSED,
+            reason="crop unlock artifact missing; run crop --strict-floats first",
+        )
+
+    try:
+        token = load_stretch_unlock(path)
+    except (OSError, ValueError, KeyError, json.JSONDecodeError) as exc:
+        return StretchGateDecision(
+            allowed=False,
+            status=StretchStatus.FULL_REFUSED,
+            reason=f"invalid crop unlock artifact: {exc}",
+        )
+
+    if not token.strict_floats:
+        return StretchGateDecision(
+            allowed=False,
+            status=StretchStatus.FULL_REFUSED,
+            reason="unlock was not produced under strict_floats",
+        )
+
+    if Path(token.oracle_root).resolve() != Path(oracle_root).resolve():
+        return StretchGateDecision(
+            allowed=False,
+            status=StretchStatus.FULL_REFUSED,
+            reason="unlock oracle_root does not match requested full oracle",
+        )
+
+    if not field_set_covers(token.field_set, requested_field_set):
+        need = requested_field_set.value
+        have = token.field_set.value
+        return StretchGateDecision(
+            allowed=False,
+            status=StretchStatus.FULL_REFUSED,
+            reason=(
+                f"unlock field_set={have!r} does not authorize requested "
+                f"field_set={need!r} (energy-only unlock cannot claim discrete)"
+            ),
+        )
+
+    return StretchGateDecision(
+        allowed=True,
+        status=StretchStatus.FULL_RUNNING,
+        reason="crop unlock matches requested field set and oracle",
+    )
+
+
+def write_stretch_status(
+    path: Path,
+    *,
+    status: StretchStatus,
+    note: str = "",
+    findings_path: Path | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Write stretch status JSON without mutating ONE TRUTH CLOSED docs.
+
+    ``findings_path`` is accepted only so callers can pass the findings file for
+    AE4 checks; this function never writes to that path.
+    """
+    del findings_path  # intentionally unused — never mutate ONE TRUTH
+    payload: dict[str, Any] = {
+        "schema_version": STATUS_SCHEMA_VERSION,
+        "status": status.value,
+        "note": note,
+        "phase1_claim_untouched": True,
+        "phase1_claim_run": PHASE1_CLAIM_RUN_NAME,
+    }
+    if extra:
+        payload["extra"] = extra
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def mkl_spike_cannot_complete_stretch(*, mkl_bit_equal: bool) -> bool:
+    """Policy: an MKL falsifier pass alone never means Approach A / stretch complete."""
+    del mkl_bit_equal
+    return True

--- a/slavv_python/analytics/parity/runs/jobs.py
+++ b/slavv_python/analytics/parity/runs/jobs.py
@@ -38,6 +38,7 @@ def build_resume_exact_run_command(
     force_kill: bool = False,
     skip_preflight: bool = False,
     n_jobs: int | None = None,
+    energy_float_backend: str | None = None,
     python_executable: Path | None = None,
 ) -> list[str]:
     """Build the command used by detached exact-route resume jobs."""
@@ -63,6 +64,8 @@ def build_resume_exact_run_command(
         command.extend(["--memory-safety-fraction", str(memory_safety_fraction)])
     if n_jobs is not None:
         command.extend(["--n-jobs", str(n_jobs)])
+    if energy_float_backend is not None:
+        command.extend(["--energy-float-backend", str(energy_float_backend)])
     if force:
         command.append("--force")
     if force_kill:
@@ -84,6 +87,7 @@ def launch_exact_run_job(
     force_kill: bool = False,
     skip_preflight: bool = False,
     n_jobs: int | None = None,
+    energy_float_backend: str | None = None,
     python_executable: Path | None = None,
     command_override: list[str] | None = None,
 ) -> dict[str, Any]:
@@ -108,6 +112,7 @@ def launch_exact_run_job(
         force_kill=force_kill,
         skip_preflight=skip_preflight,
         n_jobs=n_jobs,
+        energy_float_backend=energy_float_backend,
         python_executable=python_executable,
     )
 

--- a/slavv_python/analytics/parity/runs/launch_prepare.py
+++ b/slavv_python/analytics/parity/runs/launch_prepare.py
@@ -107,6 +107,7 @@ def prepare_detached_exact_run_launch(
     skip_preflight: bool,
     skip_foreground_probe: bool,
     n_jobs: int | None,
+    energy_float_backend: str | None = None,
     python_executable: Path | None = None,
 ) -> tuple[list[str], list[str]]:
     """Reconcile stale state, preflight, and foreground probe before detach."""
@@ -154,6 +155,7 @@ def prepare_detached_exact_run_launch(
         force_kill=force_kill,
         skip_preflight=True,
         n_jobs=n_jobs,
+        energy_float_backend=energy_float_backend,
         python_executable=python_executable,
     )
     return detached_command, foreground_command

--- a/slavv_python/analytics/parity/runs/resume.py
+++ b/slavv_python/analytics/parity/runs/resume.py
@@ -21,7 +21,7 @@ from slavv_python.analytics.parity.oracle.surfaces import (
 )
 from slavv_python.analytics.parity.runs.bootstrap import _reorient_exact_input_volume
 from slavv_python.analytics.parity.runs.preflight import run_exact_preflight_for_surfaces
-from slavv_python.analytics.parity.utils import string_or_none
+from slavv_python.analytics.parity.utils import string_or_none, write_json_with_hash
 from slavv_python.engine import SlavvPipeline
 from slavv_python.engine.constants import STATUS_PENDING
 from slavv_python.engine.state import RunContext, load_json_dict
@@ -159,6 +159,7 @@ def resume_exact_run(
         params["energy_float_backend"] = str(energy_float_backend).strip().lower()
         if params["energy_float_backend"] == "matlab_engine":
             params["n_jobs"] = 1
+        write_json_with_hash(params_path, cast("dict[str, Any]", params))
 
     effective_stop_after = stop_after or str(provenance.get("stop_after") or "network")
 

--- a/slavv_python/analytics/parity/runs/resume.py
+++ b/slavv_python/analytics/parity/runs/resume.py
@@ -119,6 +119,7 @@ def resume_exact_run(
     force: bool = False,
     skip_preflight: bool = False,
     n_jobs: int | None = None,
+    energy_float_backend: str | None = None,
 ) -> Path:
     """Resume SlavvPipeline in an init-exact-run directory after preflight checks."""
     dest_run_root = dest_run_root.expanduser().resolve()
@@ -154,6 +155,10 @@ def resume_exact_run(
         raise FileNotFoundError(f"missing validated params: {params_path}")
     if n_jobs is not None:
         params["n_jobs"] = int(n_jobs)
+    if energy_float_backend is not None:
+        params["energy_float_backend"] = str(energy_float_backend).strip().lower()
+        if params["energy_float_backend"] == "matlab_engine":
+            params["n_jobs"] = 1
 
     effective_stop_after = stop_after or str(provenance.get("stop_after") or "network")
 

--- a/slavv_python/analytics/parity/runs/writer_session.py
+++ b/slavv_python/analytics/parity/runs/writer_session.py
@@ -210,6 +210,7 @@ def launch_writer_session(
     skip_preflight: bool = False,
     skip_foreground_probe: bool = False,
     n_jobs: int | None = None,
+    energy_float_backend: str | None = None,
     monitor: bool = False,
     python_executable: Path | None = None,
 ) -> dict[str, Any]:
@@ -237,6 +238,7 @@ def launch_writer_session(
         skip_preflight=skip_preflight,
         skip_foreground_probe=skip_foreground_probe,
         n_jobs=n_jobs,
+        energy_float_backend=energy_float_backend,
         python_executable=python_executable,
     )
 
@@ -255,6 +257,7 @@ def launch_writer_session(
         force=force,
         skip_preflight=True,
         n_jobs=n_jobs,
+        energy_float_backend=energy_float_backend,
         command_override=detached_command,
         python_executable=python_executable,
     )

--- a/slavv_python/pipeline/edges/discovery.py
+++ b/slavv_python/pipeline/edges/discovery.py
@@ -36,7 +36,7 @@ from slavv_python.pipeline.edges.candidate_manifest import (
     CandidateManifest,
     candidate_as_payload,
 )
-from slavv_python.pipeline.energy.provenance import is_exact_compatible_energy_origin
+from slavv_python.pipeline.energy.provenance import is_watershed_allowed_energy_origin
 from slavv_python.pipeline.policy import PipelinePolicy
 from slavv_python.pipeline.vertices.painting import paint_vertex_image
 
@@ -53,11 +53,19 @@ def _use_watershed_discovery(energy_data: dict[str, Any], params: dict[str, Any]
     """Return True when Exact Route Watershed Discovery should run.
 
     Requires MATLAB grid alignment and exact-compatible energy provenance.
+    Stretch mode additionally allows ``matlab_engine_hessian`` without widening
+    Phase 1 ``EXACT_COMPATIBLE_ENERGY_ORIGINS``.
     """
     policy = PipelinePolicy.from_params(params)
     if policy.internal_grid_alignment != "matlab":
         return False
-    return is_exact_compatible_energy_origin(energy_data.get("energy_origin"))
+    stretch_mode = bool(params.get("stretch_zero_tolerance", False)) or (
+        str(params.get("energy_float_backend", "numpy")).strip().lower() == "matlab_engine"
+    )
+    return is_watershed_allowed_energy_origin(
+        energy_data.get("energy_origin"),
+        stretch_mode=stretch_mode,
+    )
 
 
 # Legacy name — same predicate as ``_use_watershed_discovery``.

--- a/slavv_python/pipeline/energy/chunking.py
+++ b/slavv_python/pipeline/energy/chunking.py
@@ -98,7 +98,12 @@ def _energy_result_payload(
         pixels_per_sigma_PSF=config["pixels_per_sigma_PSF"],
         microns_per_sigma_PSF=config["microns_per_sigma_PSF"],
         energy_sign=config["energy_sign"],
-        energy_origin=energy_origin_for_method(str(config["energy_method"])),
+        energy_origin=energy_origin_for_method(
+            str(config["energy_method"]),
+            energy_float_backend=str(
+                config.get("energy_float_backend", "numpy")
+            ),
+        ),
     )
     if energy_4d is not None:
         result.extra["energy_4d"] = energy_4d

--- a/slavv_python/pipeline/energy/chunking.py
+++ b/slavv_python/pipeline/energy/chunking.py
@@ -100,9 +100,7 @@ def _energy_result_payload(
         energy_sign=config["energy_sign"],
         energy_origin=energy_origin_for_method(
             str(config["energy_method"]),
-            energy_float_backend=str(
-                config.get("energy_float_backend", "numpy")
-            ),
+            energy_float_backend=str(config.get("energy_float_backend", "numpy")),
         ),
     )
     if energy_4d is not None:

--- a/slavv_python/pipeline/energy/config.py
+++ b/slavv_python/pipeline/energy/config.py
@@ -110,7 +110,7 @@ def _prepare_energy_config(image: np.ndarray, params: dict[str, Any]) -> dict[st
         logger.warning("Frangi filter unavailable. Falling back to Hessian.")
         energy_method = "hessian"
 
-    return {
+    result = {
         "image_shape": tuple(image.shape),
         "image_dtype": str(image.dtype),
         "microns_per_voxel": microns_per_voxel,
@@ -135,7 +135,18 @@ def _prepare_energy_config(image: np.ndarray, params: dict[str, Any]) -> dict[st
         "microns_per_sigma_PSF": microns_per_sigma_psf,
         "n_jobs": int(params.get("n_jobs", 1)),
         "comparison_exact_network": bool(params.get("comparison_exact_network", False)),
+        "scales_per_octave": float(scales_per_octave),
+        "matching_kernel_string": str(
+            params.get("matching_kernel_string", "3D gaussian conv annular pulse")
+        ),
+        "vessel_wall_thickness_in_microns": float(
+            params.get("vessel_wall_thickness_in_microns", 0.0)
+        ),
     }
+    if params.get("_stretch_engine_float_body_bound") is True:
+        result["_stretch_engine_float_body_bound"] = True
+        result["_stretch_engine_session"] = params.get("_stretch_engine_session")
+    return result
 
 
 __all__ = ["_prepare_energy_config"]

--- a/slavv_python/pipeline/energy/config.py
+++ b/slavv_python/pipeline/energy/config.py
@@ -120,9 +120,7 @@ def _prepare_energy_config(image: np.ndarray, params: dict[str, Any]) -> dict[st
         "approximating_PSF": approximating_psf,
         "energy_sign": energy_sign,
         "energy_method": energy_method,
-        "energy_float_backend": str(
-            params.get("energy_float_backend", "numpy")
-        ).strip().lower(),
+        "energy_float_backend": str(params.get("energy_float_backend", "numpy")).strip().lower(),
         "energy_projection_mode": energy_projection_mode,
         "return_all_scales": return_all_scales,
         "max_voxels": max_voxels,

--- a/slavv_python/pipeline/energy/config.py
+++ b/slavv_python/pipeline/energy/config.py
@@ -120,6 +120,9 @@ def _prepare_energy_config(image: np.ndarray, params: dict[str, Any]) -> dict[st
         "approximating_PSF": approximating_psf,
         "energy_sign": energy_sign,
         "energy_method": energy_method,
+        "energy_float_backend": str(
+            params.get("energy_float_backend", "numpy")
+        ).strip().lower(),
         "energy_projection_mode": energy_projection_mode,
         "return_all_scales": return_all_scales,
         "max_voxels": max_voxels,

--- a/slavv_python/pipeline/energy/manager.py
+++ b/slavv_python/pipeline/energy/manager.py
@@ -13,6 +13,7 @@ from slavv_python.pipeline.energy.chunking import (
     _energy_result_payload,
 )
 from slavv_python.pipeline.energy.config import _prepare_energy_config
+from slavv_python.pipeline.energy.matlab_engine_host import stretch_engine_float_body_session
 from slavv_python.pipeline.energy.resumable import calculate_energy_field_resumable
 
 if TYPE_CHECKING:
@@ -97,35 +98,36 @@ class EnergyManager:
             image = image.astype(np.float64, copy=False)
         else:
             image = image.astype(np.float32, copy=False)
-        if stage_controller is not None:
-            return calculate_energy_field_resumable(
-                image,
-                params,
-                stage_controller,
-                get_chunking_lattice_func=get_chunking_lattice_func,
-            )
-
-        config = _prepare_energy_config(image, params)
-        lattice = _energy_lattice(
-            image.shape,
-            int(config["max_voxels"]),
-            int(config["margin"]),
-            get_chunking_lattice_func,
-        )
-        if len(lattice) > 1:
-            return cast(
-                "EnergyResult",
-                _calculate_energy_field_chunked(
+        with stretch_engine_float_body_session(params) as bound_params:
+            if stage_controller is not None:
+                return calculate_energy_field_resumable(
                     image,
-                    params,
-                    config,
-                    lattice,
-                    get_chunking_lattice_func,
-                    cls.run,
-                ),
+                    bound_params,
+                    stage_controller,
+                    get_chunking_lattice_func=get_chunking_lattice_func,
+                )
+
+            config = _prepare_energy_config(image, bound_params)
+            lattice = _energy_lattice(
+                image.shape,
+                int(config["max_voxels"]),
+                int(config["margin"]),
+                get_chunking_lattice_func,
             )
-        energy_3d, scale_indices, energy_4d = _compute_direct_energy_outputs(image, config)
-        return _energy_result_payload(config, image.shape, energy_3d, scale_indices, energy_4d)
+            if len(lattice) > 1:
+                return cast(
+                    "EnergyResult",
+                    _calculate_energy_field_chunked(
+                        image,
+                        bound_params,
+                        config,
+                        lattice,
+                        get_chunking_lattice_func,
+                        cls.run,
+                    ),
+                )
+            energy_3d, scale_indices, energy_4d = _compute_direct_energy_outputs(image, config)
+            return _energy_result_payload(config, image.shape, energy_3d, scale_indices, energy_4d)
 
 
 __all__ = ["EnergyManager"]

--- a/slavv_python/pipeline/energy/matlab_energy_filter_v200.py
+++ b/slavv_python/pipeline/energy/matlab_energy_filter_v200.py
@@ -7,6 +7,8 @@ MATLAB source: ``external/Vectorization-Public/source/energy_filter_V200.m``
 Pair with: ``matlab_get_energy_v202_chunked.py`` (multi-scale mesh orchestration)
 """
 
+from __future__ import annotations
+
 import gc
 import logging
 from typing import Any, cast
@@ -18,6 +20,7 @@ from scipy.special import jv
 from slavv_python.pipeline.energy.matlab_engine_backend import (
     ensure_matlab_engine_float_backend_ready,
 )
+from slavv_python.pipeline.energy.matlab_engine_host import energy_filter_v200_from_spatial
 from slavv_python.pipeline.energy.matlab_principal_energy import compute_principal_energy
 from slavv_python.pipeline.energy.policy import EnergyPolicy
 
@@ -138,9 +141,54 @@ def compute_native_hessian_energy(
     """Compute one scale of the MATLAB-style matched-filter Hessian energy."""
     # Stretch backend must not silently execute the NumPy float body.
     ensure_matlab_engine_float_backend_ready(config)
+    session = config.get("_stretch_engine_session")
+    if session is not None:
+        return _compute_native_hessian_energy_via_engine(image, config, scale_idx, session)
     policy = EnergyPolicy.from_params(config)
     debug_outputs = _compute_native_hessian_scale_debug(image, config, scale_idx, policy=policy)
     return debug_outputs["energy"]
+
+
+def _compute_native_hessian_energy_via_engine(
+    image: np.ndarray,
+    config: dict[str, Any],
+    scale_idx: int,
+    session: Any,
+) -> np.ndarray:
+    """Bind ``energy_filter_V200`` for one downsampled scale, then upsample."""
+    policy = EnergyPolicy.from_params(config)
+    resolution_factor = np.asarray(config["scale_resolution_factors"][scale_idx], dtype=np.int16)
+    radius_microns = float(config["lumen_radius_microns"][scale_idx])
+    microns_per_pixel: np.ndarray = (
+        np.asarray(config["microns_per_voxel"], dtype=float) * resolution_factor
+    )
+    pixels_per_sigma_psf = (
+        np.asarray(config["pixels_per_sigma_PSF"], dtype=float) / resolution_factor
+    )
+    working_image = _downsample_volume(image, resolution_factor, policy=policy)
+    working = np.asfortranarray(working_image.astype(np.float64, copy=False))
+    ny, nx, nz = (int(working.shape[0]), int(working.shape[1]), int(working.shape[2]))
+    energy = energy_filter_v200_from_spatial(
+        session,
+        working,
+        matching_kernel_string=str(
+            config.get("matching_kernel_string", "3D gaussian conv annular pulse")
+        ),
+        radius=radius_microns,
+        vessel_wall=float(config.get("vessel_wall_thickness_in_microns", 0.0)),
+        microns_per_pixel=microns_per_pixel,
+        pixels_per_sigma_psf=pixels_per_sigma_psf,
+        y0=1,
+        y1=ny,
+        x0=1,
+        x1=nx,
+        z0=1,
+        z1=nz,
+        gaussian_to_ideal_ratio=float(config["gaussian_to_ideal_ratio"]),
+        spherical_to_annular_ratio=float(config["spherical_to_annular_ratio"]),
+        scales_per_octave=float(config.get("scales_per_octave", 1.5)),
+    )
+    return _upsample_volume(energy, image.shape, resolution_factor)
 
 
 def _compute_native_hessian_scale_debug(

--- a/slavv_python/pipeline/energy/matlab_energy_filter_v200.py
+++ b/slavv_python/pipeline/energy/matlab_energy_filter_v200.py
@@ -15,6 +15,9 @@ import numpy as np
 from scipy.ndimage import map_coordinates
 from scipy.special import jv
 
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    ensure_matlab_engine_float_backend_ready,
+)
 from slavv_python.pipeline.energy.matlab_principal_energy import compute_principal_energy
 from slavv_python.pipeline.energy.policy import EnergyPolicy
 
@@ -133,6 +136,8 @@ def compute_native_hessian_energy(
     scale_idx: int,
 ) -> np.ndarray:
     """Compute one scale of the MATLAB-style matched-filter Hessian energy."""
+    # Stretch backend must not silently execute the NumPy float body.
+    ensure_matlab_engine_float_backend_ready(config)
     policy = EnergyPolicy.from_params(config)
     debug_outputs = _compute_native_hessian_scale_debug(image, config, scale_idx, policy=policy)
     return debug_outputs["energy"]

--- a/slavv_python/pipeline/energy/matlab_engine_backend.py
+++ b/slavv_python/pipeline/energy/matlab_engine_backend.py
@@ -1,0 +1,269 @@
+"""In-process MATLAB Engine adapter for stretch Energy float math.
+
+Default Phase 1 Energy remains NumPy (``python_native_hessian``). This module
+is the Approach A float path (KTD2/KTD3): one long-lived engine per Energy job,
+Fortran-order array transfer, no ``.tolist()`` volume marshalling.
+
+Missing MATLAB / unsupported Python / license failures raise
+``MatlabEngineInfraError`` → stretch status ``incomplete_infra`` (never
+``blocked_float_path``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# R2019a-era Engine for Python support window (setup.py on this host).
+_SUPPORTED_PYTHON_PREFIXES = ("2.7", "3.5", "3.6", "3.7")
+
+
+class MatlabEngineInfraError(RuntimeError):
+    """MATLAB / engine / license / version infra failure (incomplete_infra)."""
+
+
+class MatlabEnginePolicyError(ValueError):
+    """Caller asked for a forbidden stretch success definition (e.g. R6)."""
+
+
+@dataclass(frozen=True)
+class MatlabEnginePrerequisites:
+    """Resolved prerequisites for starting an engine session."""
+
+    matlab_root: Path
+    vectorization_root: Path
+    python_version: str
+
+
+def matlab_engine_importable() -> bool:
+    """Return True when ``matlab.engine`` can be imported in this interpreter."""
+    try:
+        import matlab.engine  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def resolve_matlab_root(matlab_exe: str | Path | None = None) -> Path:
+    """Resolve the MATLAB install root from ``matlab.exe`` or ``MATLAB_EXE``."""
+    executable = (
+        str(matlab_exe)
+        if matlab_exe
+        else os.environ.get("MATLAB_EXE") or shutil.which("matlab.exe") or shutil.which("matlab")
+    )
+    if not executable:
+        raise MatlabEngineInfraError(
+            "MATLAB executable unavailable; set MATLAB_EXE or put matlab on PATH"
+        )
+    exe_path = Path(executable)
+    if not exe_path.is_file():
+        raise MatlabEngineInfraError(f"MATLAB executable not found: {exe_path}")
+    # …/bin/matlab.exe → install root
+    return exe_path.resolve().parent.parent
+
+
+def default_vectorization_root() -> Path:
+    """Vendored Vectorization-Public source root."""
+    return Path(__file__).resolve().parents[3] / "external" / "Vectorization-Public"
+
+
+def verify_matlab_engine_prerequisites(
+    *,
+    matlab_exe: str | Path | None = None,
+    vectorization_root: Path | None = None,
+) -> MatlabEnginePrerequisites:
+    """Fail fast when engine stretch path cannot run on this host."""
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    if not any(version.startswith(prefix) for prefix in _SUPPORTED_PYTHON_PREFIXES):
+        raise MatlabEngineInfraError(
+            "MATLAB Engine for Python (R2019a) supports Python "
+            f"{', '.join(_SUPPORTED_PYTHON_PREFIXES)}, but this interpreter is "
+            f"{sys.version.split()[0]} — stretch Energy must use a compatible "
+            "operator Python (incomplete_infra)"
+        )
+    matlab_root = resolve_matlab_root(matlab_exe)
+    root = Path(vectorization_root) if vectorization_root else default_vectorization_root()
+    if not root.is_dir():
+        raise MatlabEngineInfraError(f"Vectorization-Public unavailable: {root}")
+    source = root / "source"
+    if not source.is_dir():
+        raise MatlabEngineInfraError(f"Vectorization-Public source missing: {source}")
+    if not matlab_engine_importable():
+        raise MatlabEngineInfraError(
+            "matlab.engine is not importable; install MATLAB Engine for Python "
+            "into this interpreter (incomplete_infra)"
+        )
+    return MatlabEnginePrerequisites(
+        matlab_root=matlab_root,
+        vectorization_root=root,
+        python_version=version,
+    )
+
+
+def numpy_to_matlab_double(array: np.ndarray) -> Any:
+    """Convert a float64 ndarray to ``matlab.double`` without ndarray ``.tolist()``.
+
+    Packs a Fortran-order flat sequence and sets ``size`` so MATLAB receives
+    column-major ``[Y, X, Z]`` layout without a C-order nested ``.tolist()``.
+    """
+    try:
+        import matlab
+    except Exception as exc:
+        raise MatlabEngineInfraError(
+            f"matlab package unavailable for array transfer: {exc}"
+        ) from exc
+
+    arr = np.asfortranarray(np.asarray(array, dtype=np.float64))
+    if arr.ndim == 0:
+        return matlab.double([float(arr)])
+    flat = np.ravel(arr, order="F")
+    # Element iterator avoids ndarray.tolist(); size= restores MATLAB shape.
+    sequence = [float(value) for value in flat]
+    size = [int(dim) for dim in arr.shape]
+    try:
+        return matlab.double(sequence, size=size)
+    except TypeError:
+        # Older constructors may reject size=; fall back to column vector.
+        return matlab.double(sequence)
+
+
+def matlab_double_to_numpy(matlab_array: Any, shape: tuple[int, ...]) -> np.ndarray:
+    """Convert ``matlab.double`` back to float64 ndarray with given shape (F-order)."""
+    data = getattr(matlab_array, "_data", None)
+    if data is not None:
+        flat = np.frombuffer(data, dtype=np.float64).copy()
+        return np.ascontiguousarray(np.reshape(flat, shape, order="F"))
+    as_array = np.asarray(matlab_array, dtype=np.float64)
+    if tuple(as_array.shape) == shape:
+        return np.ascontiguousarray(as_array)
+    flat = np.ravel(as_array, order="F")
+    return np.ascontiguousarray(np.reshape(flat, shape, order="F"))
+
+
+def refuse_matlab_only_energy_checkpoint_as_stretch_success() -> None:
+    """R6: MATLAB-written Energy alone is not stretch success."""
+    raise MatlabEnginePolicyError(
+        "loading a MATLAB-only Energy checkpoint is not stretch success; "
+        "Python must produce Energy under orchestration (R6)"
+    )
+
+
+def ensure_matlab_engine_float_backend_ready(config: dict[str, Any]) -> None:
+    """Refuse NumPy float-body execution under ``energy_float_backend=matlab_engine``.
+
+    When the stretch backend is selected, either a bound engine float body must
+    be active (``config['_stretch_engine_float_body_bound']=True`` set by the
+    job session) or this raises ``MatlabEngineInfraError``. Never fall back to
+    NumPy while stamping ``matlab_engine_hessian``.
+    """
+    backend = str(config.get("energy_float_backend", "numpy")).strip().lower()
+    if backend != "matlab_engine":
+        return
+    if config.get("_stretch_engine_float_body_bound") is True:
+        verify_matlab_engine_prerequisites(
+            matlab_exe=config.get("matlab_exe"),
+            vectorization_root=(
+                Path(config["vectorization_root"]) if config.get("vectorization_root") else None
+            ),
+        )
+        return
+    # Probe infra first so unsupported Python / missing engine classify correctly.
+    verify_matlab_engine_prerequisites(
+        matlab_exe=config.get("matlab_exe"),
+        vectorization_root=(
+            Path(config["vectorization_root"]) if config.get("vectorization_root") else None
+        ),
+    )
+    raise MatlabEngineInfraError(
+        "matlab_engine backend selected but Energy float body is not bound to "
+        "the MATLAB session; refusing NumPy execution under stretch origin "
+        "(incomplete_infra — deepen energy_filter_V200 engine ownership)"
+    )
+
+
+class MatlabEngineSession:
+    """One long-lived MATLAB engine for a stretch Energy job."""
+
+    def __init__(
+        self,
+        *,
+        matlab_exe: str | Path | None = None,
+        vectorization_root: Path | None = None,
+    ) -> None:
+        self._prereqs = verify_matlab_engine_prerequisites(
+            matlab_exe=matlab_exe,
+            vectorization_root=vectorization_root,
+        )
+        self._engine: Any | None = None
+
+    def __enter__(self) -> MatlabEngineSession:
+        self.start()
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.quit()
+
+    @property
+    def engine(self) -> Any:
+        if self._engine is None:
+            raise MatlabEngineInfraError("MATLAB engine session is not started")
+        return self._engine
+
+    def start(self) -> None:
+        if self._engine is not None:
+            return
+        try:
+            import matlab.engine
+        except Exception as exc:
+            raise MatlabEngineInfraError(f"failed to import matlab.engine: {exc}") from exc
+        try:
+            self._engine = matlab.engine.start_matlab()
+        except Exception as exc:
+            raise MatlabEngineInfraError(
+                f"failed to start MATLAB engine (license/version?): {exc}"
+            ) from exc
+        source = str(self._prereqs.vectorization_root / "source")
+        try:
+            self._engine.addpath(source, nargout=0)
+        except Exception as exc:
+            self.quit()
+            raise MatlabEngineInfraError(f"addpath failed for {source}: {exc}") from exc
+        logger.info("MATLAB engine started for stretch Energy; addpath=%s", source)
+
+    def quit(self) -> None:
+        eng = self._engine
+        self._engine = None
+        if eng is None:
+            return
+        try:
+            eng.quit()
+        except Exception as exc:
+            logger.warning("MATLAB engine quit raised: %s", exc)
+
+    def call(self, name: str, *args: Any, nargout: int = 1) -> Any:
+        """Invoke a MATLAB function by name; path-miss → infra error."""
+        try:
+            func = getattr(self.engine, name)
+        except AttributeError as exc:
+            raise MatlabEngineInfraError(f"MATLAB function not found on path: {name}") from exc
+        try:
+            return func(*args, nargout=nargout)
+        except Exception as exc:
+            raise MatlabEngineInfraError(f"MATLAB call {name!r} failed: {exc}") from exc
+
+    def roundtrip_float64(self, array: np.ndarray) -> np.ndarray:
+        """Identity round-trip through ``matlab.double`` for transfer tests."""
+        shape = tuple(int(s) for s in np.asarray(array).shape)
+        ml = numpy_to_matlab_double(array)
+        # Use reshape in MATLAB to preserve size, then convert back.
+        restored = matlab_double_to_numpy(ml, shape)
+        return restored.astype(np.float64, copy=False)

--- a/slavv_python/pipeline/energy/matlab_engine_backend.py
+++ b/slavv_python/pipeline/energy/matlab_engine_backend.py
@@ -17,7 +17,7 @@ import shutil
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -42,6 +42,12 @@ class MatlabEnginePrerequisites:
     matlab_root: Path
     vectorization_root: Path
     python_version: str
+
+
+def current_python_supports_r2019a_engine() -> bool:
+    """Return True when this interpreter is in the R2019a Engine ABI window."""
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    return any(version.startswith(prefix) for prefix in _SUPPORTED_PYTHON_PREFIXES)
 
 
 def matlab_engine_importable() -> bool:
@@ -83,7 +89,7 @@ def verify_matlab_engine_prerequisites(
 ) -> MatlabEnginePrerequisites:
     """Fail fast when engine stretch path cannot run on this host."""
     version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    if not any(version.startswith(prefix) for prefix in _SUPPORTED_PYTHON_PREFIXES):
+    if not current_python_supports_r2019a_engine():
         raise MatlabEngineInfraError(
             "MATLAB Engine for Python (R2019a) supports Python "
             f"{', '.join(_SUPPORTED_PYTHON_PREFIXES)}, but this interpreter is "
@@ -141,12 +147,12 @@ def matlab_double_to_numpy(matlab_array: Any, shape: tuple[int, ...]) -> np.ndar
     data = getattr(matlab_array, "_data", None)
     if data is not None:
         flat = np.frombuffer(data, dtype=np.float64).copy()
-        return np.ascontiguousarray(np.reshape(flat, shape, order="F"))
+        return cast("np.ndarray", np.ascontiguousarray(np.reshape(flat, shape, order="F")))
     as_array = np.asarray(matlab_array, dtype=np.float64)
     if tuple(as_array.shape) == shape:
-        return np.ascontiguousarray(as_array)
+        return cast("np.ndarray", np.ascontiguousarray(as_array))
     flat = np.ravel(as_array, order="F")
-    return np.ascontiguousarray(np.reshape(flat, shape, order="F"))
+    return cast("np.ndarray", np.ascontiguousarray(np.reshape(flat, shape, order="F")))
 
 
 def refuse_matlab_only_energy_checkpoint_as_stretch_success() -> None:
@@ -169,12 +175,6 @@ def ensure_matlab_engine_float_backend_ready(config: dict[str, Any]) -> None:
     if backend != "matlab_engine":
         return
     if config.get("_stretch_engine_float_body_bound") is True:
-        verify_matlab_engine_prerequisites(
-            matlab_exe=config.get("matlab_exe"),
-            vectorization_root=(
-                Path(config["vectorization_root"]) if config.get("vectorization_root") else None
-            ),
-        )
         return
     # Probe infra first so unsupported Python / missing engine classify correctly.
     verify_matlab_engine_prerequisites(

--- a/slavv_python/pipeline/energy/matlab_engine_host.py
+++ b/slavv_python/pipeline/energy/matlab_engine_host.py
@@ -2,7 +2,8 @@
 
 Repo slavv runs on Python >=3.11; R2019a ``matlab.engine`` supports <=3.7.
 This module starts one long-lived 3.7 worker (or in-process engine when the
-current interpreter is 3.7) and binds ``energy_filter_V200`` as the float body.
+current interpreter is 3.7) and binds ``energy_filter_V200`` plus the per-chunk
+``interp3`` / scale-min body (``stretch_energy_chunk_v202``).
 """
 
 from __future__ import annotations
@@ -268,6 +269,80 @@ class MatlabEnginePy37Worker:
         energy = np.load(out_path)
         return cast("np.ndarray", np.ascontiguousarray(np.asarray(energy, dtype=np.float64)))
 
+    def energy_chunk_v202_from_spatial(
+        self,
+        chunk: np.ndarray,
+        *,
+        matching_kernel_string: str,
+        radii: np.ndarray,
+        vessel_wall: float,
+        microns_per_pixel: np.ndarray,
+        pixels_per_sigma_psf: np.ndarray,
+        y0: int,
+        y1: int,
+        x0: int,
+        x1: int,
+        z0: int,
+        z1: int,
+        y_offset: int,
+        x_offset: int,
+        z_offset: int,
+        y_write_count: int,
+        x_write_count: int,
+        z_write_count: int,
+        rf_y: int,
+        rf_x: int,
+        rf_z: int,
+        gaussian_to_ideal_ratio: float,
+        spherical_to_annular_ratio: float,
+        scales_per_octave: float,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        if self._tmpdir is None:
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker tempdir missing")
+        work = Path(self._tmpdir.name)
+        chunk_path = work / "chunk.npy"
+        energy_path = work / "chunk_energy.npy"
+        scale_path = work / "chunk_scale.npy"
+        np.save(chunk_path, np.asfortranarray(np.asarray(chunk, dtype=np.float64)))
+        reply = self._request(
+            {
+                "op": "energy_chunk",
+                "chunk_npy": str(chunk_path),
+                "energy_npy": str(energy_path),
+                "scale_npy": str(scale_path),
+                "matching_kernel_string": matching_kernel_string,
+                "radii": np.asarray(radii, dtype=np.float64).reshape(-1).tolist(),
+                "vessel_wall": float(vessel_wall),
+                "microns_per_pixel": np.asarray(microns_per_pixel, dtype=np.float64).tolist(),
+                "pixels_per_sigma_psf": np.asarray(pixels_per_sigma_psf, dtype=np.float64).tolist(),
+                "y0": int(y0),
+                "y1": int(y1),
+                "x0": int(x0),
+                "x1": int(x1),
+                "z0": int(z0),
+                "z1": int(z1),
+                "y_offset": int(y_offset),
+                "x_offset": int(x_offset),
+                "z_offset": int(z_offset),
+                "y_write_count": int(y_write_count),
+                "x_write_count": int(x_write_count),
+                "z_write_count": int(z_write_count),
+                "rf_y": int(rf_y),
+                "rf_x": int(rf_x),
+                "rf_z": int(rf_z),
+                "gaussian_to_ideal_ratio": float(gaussian_to_ideal_ratio),
+                "spherical_to_annular_ratio": float(spherical_to_annular_ratio),
+                "scales_per_octave": float(scales_per_octave),
+            }
+        )
+        if not reply.get("ok"):
+            raise MatlabEngineInfraError(
+                f"stretch_energy_chunk_v202 worker call failed: {reply.get('error')}"
+            )
+        energy = np.ascontiguousarray(np.asarray(np.load(energy_path), dtype=np.float64))
+        scale_idx = np.ascontiguousarray(np.asarray(np.load(scale_path), dtype=np.float64))
+        return energy, scale_idx
+
 
 def energy_filter_v200_from_spatial(
     session: MatlabEngineSession | MatlabEnginePy37Worker,
@@ -330,6 +405,98 @@ def energy_filter_v200_from_spatial(
     )
     shape = (int(y1) - int(y0) + 1, int(x1) - int(x0) + 1, int(z1) - int(z0) + 1)
     return matlab_double_to_numpy(energy, shape)
+
+
+def energy_chunk_v202_from_spatial(
+    session: MatlabEngineSession | MatlabEnginePy37Worker,
+    chunk: np.ndarray,
+    *,
+    matching_kernel_string: str = DEFAULT_MATCHING_KERNEL,
+    radii: np.ndarray,
+    vessel_wall: float = 0.0,
+    microns_per_pixel: np.ndarray,
+    pixels_per_sigma_psf: np.ndarray,
+    y0: int,
+    y1: int,
+    x0: int,
+    x1: int,
+    z0: int,
+    z1: int,
+    y_offset: int,
+    x_offset: int,
+    z_offset: int,
+    y_write_count: int,
+    x_write_count: int,
+    z_write_count: int,
+    rf_y: int,
+    rf_x: int,
+    rf_z: int,
+    gaussian_to_ideal_ratio: float,
+    spherical_to_annular_ratio: float,
+    scales_per_octave: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Call ``stretch_energy_chunk_v202`` (FFT + filter + MATLAB ``interp3`` + min)."""
+    if isinstance(session, MatlabEnginePy37Worker):
+        return session.energy_chunk_v202_from_spatial(
+            chunk,
+            matching_kernel_string=matching_kernel_string,
+            radii=radii,
+            vessel_wall=vessel_wall,
+            microns_per_pixel=microns_per_pixel,
+            pixels_per_sigma_psf=pixels_per_sigma_psf,
+            y0=y0,
+            y1=y1,
+            x0=x0,
+            x1=x1,
+            z0=z0,
+            z1=z1,
+            y_offset=y_offset,
+            x_offset=x_offset,
+            z_offset=z_offset,
+            y_write_count=y_write_count,
+            x_write_count=x_write_count,
+            z_write_count=z_write_count,
+            rf_y=rf_y,
+            rf_x=rf_x,
+            rf_z=rf_z,
+            gaussian_to_ideal_ratio=gaussian_to_ideal_ratio,
+            spherical_to_annular_ratio=spherical_to_annular_ratio,
+            scales_per_octave=scales_per_octave,
+        )
+    ml_chunk = numpy_to_matlab_double(chunk)
+    microns = numpy_to_matlab_double(np.asarray(microns_per_pixel, dtype=np.float64).reshape(-1))
+    psf = numpy_to_matlab_double(np.asarray(pixels_per_sigma_psf, dtype=np.float64).reshape(-1))
+    ml_radii = numpy_to_matlab_double(np.asarray(radii, dtype=np.float64).reshape(-1))
+    energy, scale_idx = session.call(
+        "stretch_energy_chunk_v202",
+        ml_chunk,
+        matching_kernel_string,
+        ml_radii,
+        float(vessel_wall),
+        microns,
+        psf,
+        float(y0),
+        float(y1),
+        float(x0),
+        float(x1),
+        float(z0),
+        float(z1),
+        float(y_offset),
+        float(x_offset),
+        float(z_offset),
+        float(y_write_count),
+        float(x_write_count),
+        float(z_write_count),
+        float(rf_y),
+        float(rf_x),
+        float(rf_z),
+        float(gaussian_to_ideal_ratio),
+        float(spherical_to_annular_ratio),
+        float(scales_per_octave),
+        nargout=2,
+    )
+    shape = (int(y_write_count), int(x_write_count), int(z_write_count))
+    return matlab_double_to_numpy(energy, shape), matlab_double_to_numpy(scale_idx, shape)
 
 
 @contextmanager

--- a/slavv_python/pipeline/energy/matlab_engine_host.py
+++ b/slavv_python/pipeline/energy/matlab_engine_host.py
@@ -1,0 +1,389 @@
+"""Python 3.7 MATLAB Engine host for stretch Energy (R2019a ABI).
+
+Repo slavv runs on Python >=3.11; R2019a ``matlab.engine`` supports <=3.7.
+This module starts one long-lived 3.7 worker (or in-process engine when the
+current interpreter is 3.7) and binds ``energy_filter_V200`` as the float body.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import numpy as np
+
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    MatlabEngineInfraError,
+    MatlabEngineSession,
+    current_python_supports_r2019a_engine,
+    default_vectorization_root,
+    matlab_double_to_numpy,
+    numpy_to_matlab_double,
+    resolve_matlab_root,
+    verify_matlab_engine_prerequisites,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+logger = logging.getLogger(__name__)
+
+STRETCH_PY37_ENV = "STRETCH_PY37_PYTHON"
+DEFAULT_MATCHING_KERNEL = "3D gaussian conv annular pulse"
+WORKER_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "stretch_matlab_engine_worker.py"
+HELPER_DIR = Path(__file__).resolve().parents[3] / "scripts"
+
+
+def default_isolated_python37() -> Path:
+    """Repo-local isolated 3.7 prefix (conda or venv), if present."""
+    root = Path(__file__).resolve().parents[3]
+    scratch = root / "workspace" / "scratch"
+    for candidate in (
+        scratch / "conda_py37_stretch" / "python.exe",
+        scratch / "conda_py37_stretch" / "Scripts" / "python.exe",
+        scratch / "venv_py37_stretch" / "Scripts" / "python.exe",
+    ):
+        if candidate.is_file():
+            return candidate
+    return scratch / "conda_py37_stretch" / "python.exe"
+
+
+def resolve_python37_executable() -> Path | None:
+    """Locate a Python 3.7 interpreter without using the repo 3.12 venv."""
+    env_path = os.environ.get(STRETCH_PY37_ENV)
+    candidates: list[Path] = []
+    if env_path:
+        candidates.append(Path(env_path))
+    isolated = default_isolated_python37()
+    if isolated.is_file():
+        candidates.append(isolated)
+    which_37 = shutil.which("python3.7")
+    if which_37:
+        candidates.append(Path(which_37))
+    anaconda = Path(r"C:\ProgramData\Anaconda3\python.exe")
+    if anaconda.is_file():
+        candidates.append(anaconda)
+    seen: set[str] = set()
+    for candidate in candidates:
+        resolved = str(candidate.resolve()) if candidate.is_file() else ""
+        if not resolved or resolved in seen:
+            continue
+        seen.add(resolved)
+        if _python_is_37(candidate):
+            return candidate.resolve()
+    py_launcher = shutil.which("py")
+    if py_launcher:
+        try:
+            completed = subprocess.run(
+                [py_launcher, "-3.7", "-c", "import sys; print(sys.executable)"],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            completed = None
+        if completed is not None and completed.returncode == 0:
+            path = Path(completed.stdout.strip())
+            if path.is_file() and _python_is_37(path):
+                return path.resolve()
+    return None
+
+
+def _python_is_37(executable: Path) -> bool:
+    try:
+        completed = subprocess.run(
+            [str(executable), "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return completed.returncode == 0 and completed.stdout.strip() == "3.7"
+
+
+class MatlabEnginePy37Worker:
+    """Long-lived Python 3.7 subprocess hosting ``matlab.engine``."""
+
+    def __init__(
+        self,
+        python37: Path,
+        *,
+        vectorization_root: Path,
+        helper_dir: Path = HELPER_DIR,
+    ) -> None:
+        self._python37 = python37
+        self._vectorization_root = vectorization_root
+        self._helper_dir = helper_dir
+        self._proc: subprocess.Popen[str] | None = None
+        self._tmpdir: tempfile.TemporaryDirectory[str] | None = None
+
+    def start(self) -> None:
+        if self._proc is not None:
+            return
+        if not WORKER_SCRIPT.is_file():
+            raise MatlabEngineInfraError(f"stretch engine worker missing: {WORKER_SCRIPT}")
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="slavv_stretch_engine_")
+        matlab_bin = resolve_matlab_root() / "bin" / "win64"
+        env = os.environ.copy()
+        env["PATH"] = str(matlab_bin) + os.pathsep + env.get("PATH", "")
+        try:
+            self._proc = subprocess.Popen(
+                [str(self._python37), "-u", str(WORKER_SCRIPT)],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+                env=env,
+            )
+        except OSError as exc:
+            self._cleanup_tmpdir()
+            raise MatlabEngineInfraError(f"failed to spawn Python 3.7 worker: {exc}") from exc
+        source = self._vectorization_root / "source"
+        reply = self._request(
+            {
+                "op": "start",
+                "vectorization_source": str(source),
+                "helper_dir": str(self._helper_dir),
+            }
+        )
+        if not reply.get("ok"):
+            self.quit()
+            raise MatlabEngineInfraError(
+                f"Python 3.7 matlab.engine start failed: {reply.get('error')}"
+            )
+        logger.info("stretch Energy Python 3.7 MATLAB worker started: %s", self._python37)
+
+    def quit(self) -> None:
+        proc = self._proc
+        self._proc = None
+        if proc is not None and proc.stdin is not None:
+            try:
+                proc.stdin.write(json.dumps({"op": "quit"}) + "\n")
+                proc.stdin.flush()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=30)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+        self._cleanup_tmpdir()
+
+    def _cleanup_tmpdir(self) -> None:
+        tmp = self._tmpdir
+        self._tmpdir = None
+        if tmp is not None:
+            tmp.cleanup()
+
+    def _request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        proc = self._proc
+        if proc is None or proc.stdin is None or proc.stdout is None:
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker is not started")
+        try:
+            proc.stdin.write(json.dumps(payload) + "\n")
+            proc.stdin.flush()
+            line = proc.stdout.readline()
+        except OSError as exc:
+            err = ""
+            if proc.stderr is not None:
+                err = proc.stderr.read()
+            raise MatlabEngineInfraError(
+                f"Python 3.7 MATLAB worker I/O failed: {exc}; stderr={err!r}"
+            ) from exc
+        if not line:
+            err = ""
+            if proc.stderr is not None:
+                err = proc.stderr.read()
+            raise MatlabEngineInfraError(f"Python 3.7 MATLAB worker exited; stderr={err!r}")
+        try:
+            reply = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise MatlabEngineInfraError(
+                f"Python 3.7 MATLAB worker returned non-JSON: {line!r}"
+            ) from exc
+        if not isinstance(reply, dict):
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker reply must be an object")
+        return reply
+
+    def energy_filter_v200_from_spatial(
+        self,
+        chunk: np.ndarray,
+        *,
+        matching_kernel_string: str,
+        radius: float,
+        vessel_wall: float,
+        microns_per_pixel: np.ndarray,
+        pixels_per_sigma_psf: np.ndarray,
+        y0: int,
+        y1: int,
+        x0: int,
+        x1: int,
+        z0: int,
+        z1: int,
+        gaussian_to_ideal_ratio: float,
+        spherical_to_annular_ratio: float,
+        scales_per_octave: float,
+    ) -> np.ndarray:
+        if self._tmpdir is None:
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker tempdir missing")
+        work = Path(self._tmpdir.name)
+        chunk_path = work / "chunk.npy"
+        out_path = work / "energy.npy"
+        np.save(chunk_path, np.asfortranarray(np.asarray(chunk, dtype=np.float64)))
+        reply = self._request(
+            {
+                "op": "energy_filter",
+                "chunk_npy": str(chunk_path),
+                "out_npy": str(out_path),
+                "matching_kernel_string": matching_kernel_string,
+                "radius": float(radius),
+                "vessel_wall": float(vessel_wall),
+                "microns_per_pixel": np.asarray(microns_per_pixel, dtype=np.float64).tolist(),
+                "pixels_per_sigma_psf": np.asarray(pixels_per_sigma_psf, dtype=np.float64).tolist(),
+                "y0": int(y0),
+                "y1": int(y1),
+                "x0": int(x0),
+                "x1": int(x1),
+                "z0": int(z0),
+                "z1": int(z1),
+                "gaussian_to_ideal_ratio": float(gaussian_to_ideal_ratio),
+                "spherical_to_annular_ratio": float(spherical_to_annular_ratio),
+                "scales_per_octave": float(scales_per_octave),
+            }
+        )
+        if not reply.get("ok"):
+            raise MatlabEngineInfraError(
+                f"energy_filter_V200 worker call failed: {reply.get('error')}"
+            )
+        energy = np.load(out_path)
+        return cast("np.ndarray", np.ascontiguousarray(np.asarray(energy, dtype=np.float64)))
+
+
+def energy_filter_v200_from_spatial(
+    session: MatlabEngineSession | MatlabEnginePy37Worker,
+    chunk: np.ndarray,
+    *,
+    matching_kernel_string: str = DEFAULT_MATCHING_KERNEL,
+    radius: float,
+    vessel_wall: float = 0.0,
+    microns_per_pixel: np.ndarray,
+    pixels_per_sigma_psf: np.ndarray,
+    y0: int,
+    y1: int,
+    x0: int,
+    x1: int,
+    z0: int,
+    z1: int,
+    gaussian_to_ideal_ratio: float,
+    spherical_to_annular_ratio: float,
+    scales_per_octave: float,
+) -> np.ndarray:
+    """Call ``stretch_energy_filter_v200`` (FFT + ``energy_filter_V200``)."""
+    if isinstance(session, MatlabEnginePy37Worker):
+        return session.energy_filter_v200_from_spatial(
+            chunk,
+            matching_kernel_string=matching_kernel_string,
+            radius=radius,
+            vessel_wall=vessel_wall,
+            microns_per_pixel=microns_per_pixel,
+            pixels_per_sigma_psf=pixels_per_sigma_psf,
+            y0=y0,
+            y1=y1,
+            x0=x0,
+            x1=x1,
+            z0=z0,
+            z1=z1,
+            gaussian_to_ideal_ratio=gaussian_to_ideal_ratio,
+            spherical_to_annular_ratio=spherical_to_annular_ratio,
+            scales_per_octave=scales_per_octave,
+        )
+    ml_chunk = numpy_to_matlab_double(chunk)
+    microns = numpy_to_matlab_double(np.asarray(microns_per_pixel, dtype=np.float64).reshape(-1))
+    psf = numpy_to_matlab_double(np.asarray(pixels_per_sigma_psf, dtype=np.float64).reshape(-1))
+    energy = session.call(
+        "stretch_energy_filter_v200",
+        ml_chunk,
+        matching_kernel_string,
+        float(radius),
+        float(vessel_wall),
+        microns,
+        psf,
+        float(y0),
+        float(y1),
+        float(x0),
+        float(x1),
+        float(z0),
+        float(z1),
+        float(gaussian_to_ideal_ratio),
+        float(spherical_to_annular_ratio),
+        float(scales_per_octave),
+    )
+    shape = (int(y1) - int(y0) + 1, int(x1) - int(x0) + 1, int(z1) - int(z0) + 1)
+    return matlab_double_to_numpy(energy, shape)
+
+
+@contextmanager
+def stretch_engine_float_body_session(config: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """Bind Energy float body for one job; no-op when backend is NumPy."""
+    backend = str(config.get("energy_float_backend", "numpy")).strip().lower()
+    if backend != "matlab_engine":
+        yield config
+        return
+    bound = dict(config)
+    bound["n_jobs"] = 1
+    matlab_exe = bound.get("matlab_exe")
+    vectorization_root = (
+        Path(bound["vectorization_root"])
+        if bound.get("vectorization_root")
+        else default_vectorization_root()
+    )
+    helper_dir = HELPER_DIR
+    session: MatlabEngineSession | MatlabEnginePy37Worker
+    if current_python_supports_r2019a_engine():
+        verify_matlab_engine_prerequisites(
+            matlab_exe=matlab_exe,
+            vectorization_root=vectorization_root,
+        )
+        session = MatlabEngineSession(
+            matlab_exe=matlab_exe,
+            vectorization_root=vectorization_root,
+        )
+        session.start()
+        session.engine.addpath(str(helper_dir), nargout=0)
+    else:
+        resolve_matlab_root(matlab_exe)
+        if not (vectorization_root / "source").is_dir():
+            raise MatlabEngineInfraError(
+                f"Vectorization-Public source missing: {vectorization_root / 'source'}"
+            )
+        python37 = resolve_python37_executable()
+        if python37 is None:
+            raise MatlabEngineInfraError(
+                "MATLAB Engine for Python (R2019a) needs Python 3.7; set "
+                f"{STRETCH_PY37_ENV} to an isolated 3.7 interpreter with matlab.engine "
+                "(incomplete_infra)"
+            )
+        session = MatlabEnginePy37Worker(
+            python37,
+            vectorization_root=vectorization_root,
+            helper_dir=helper_dir,
+        )
+        session.start()
+    bound["_stretch_engine_float_body_bound"] = True
+    bound["_stretch_engine_session"] = session
+    try:
+        yield bound
+    finally:
+        session.quit()
+        bound["_stretch_engine_float_body_bound"] = False
+        bound.pop("_stretch_engine_session", None)

--- a/slavv_python/pipeline/energy/matlab_get_energy_v202_chunked.py
+++ b/slavv_python/pipeline/energy/matlab_get_energy_v202_chunked.py
@@ -29,6 +29,10 @@ except ImportError:
     prange = range
 
 from slavv_python.pipeline.energy import matlab_energy_filter_v200 as native_hessian
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    ensure_matlab_engine_float_backend_ready,
+)
+from slavv_python.pipeline.energy.matlab_engine_host import energy_filter_v200_from_spatial
 from slavv_python.pipeline.energy.matlab_principal_energy import compute_principal_energy
 
 if TYPE_CHECKING:
@@ -353,7 +357,10 @@ def compute_exact_parity_energy_chunked(
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
     """Compute exact-route energy using MATLAB octave chunk and mesh rules."""
 
+    ensure_matlab_engine_float_backend_ready(config)
     n_jobs = max(1, int(config.get("n_jobs", 2)))
+    if str(config.get("energy_float_backend", "numpy")).strip().lower() == "matlab_engine":
+        n_jobs = 1
     image_shape = np.asarray(image.shape, dtype=float)
 
     energy_3d = np.zeros(image.shape, dtype=np.float64)
@@ -413,6 +420,9 @@ def compute_exact_parity_energy_single_octave(
 ) -> int:
     """Run exact-route energy computation for a single octave and merge in-place."""
 
+    ensure_matlab_engine_float_backend_ready(config)
+    if str(config.get("energy_float_backend", "numpy")).strip().lower() == "matlab_engine":
+        n_jobs = 1
     image_shape = np.asarray(image.shape, dtype=float)
     octave_at_scales = config["octave_at_scales"]
     microns_per_voxel = np.asarray(config["microns_per_voxel"], dtype=float)
@@ -512,10 +522,12 @@ def compute_exact_parity_energy_single_octave(
 
         padded_chunk = native_hessian._fourier_transform_input(original_chunk)
         padded_shape = padded_chunk.shape
-        chunk_dft = np.fft.fftn(padded_chunk.astype(np.float64, copy=False))
-
-        # Pre-compute pixel frequency meshes for the padded chunk once
-        pixel_freq_meshes = native_hessian._pixel_frequency_meshes(padded_chunk.shape)
+        session = config.get("_stretch_engine_session")
+        chunk_dft: np.ndarray | None = None
+        pixel_freq_meshes: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
+        if session is None:
+            chunk_dft = np.fft.fftn(padded_chunk.astype(np.float64, copy=False))
+            pixel_freq_meshes = native_hessian._pixel_frequency_meshes(padded_chunk.shape)
 
         w_count_z = int(z_write_counts[z_idx])
         w_count_y = int(y_write_counts[y_idx])
@@ -556,82 +568,103 @@ def compute_exact_parity_energy_single_octave(
         for s_sub_idx, s_idx in enumerate(scale_indices_at_octave):
             radius_of_lumen_in_microns = lumen_radius_microns[s_idx]
             pixels_per_sigma_psf_at_oct = pixels_per_sigma_PSF / rf
-
-            matching_kernel_dft, derivative_weights = native_hessian._matching_kernel_dft(
-                pixel_freq_meshes,
-                radius_of_lumen_in_microns=radius_of_lumen_in_microns,
-                microns_per_pixel=microns_per_pixel_matlab,
-                pixels_per_sigma_psf=pixels_per_sigma_psf_at_oct[[1, 2, 0]],
-                gaussian_to_ideal_ratio=float(config["gaussian_to_ideal_ratio"]),
-                spherical_to_annular_ratio=float(config["spherical_to_annular_ratio"]),
-            )
-
-            filtered_chunk_dft = matching_kernel_dft * chunk_dft
-            del matching_kernel_dft
-
             coarse_shape = (
                 y_local.stop - y_local.start,
                 x_local.stop - x_local.start,
                 z_local.stop - z_local.start,
             )
 
-            # All intermediates are [Y, X, Z] with Fortran order
-            # Compute derivative kernels one-by-one to minimize peak memory
-            curvatures_local = np.empty((6, *coarse_shape), dtype=np.float64, order="F")
-            for k_idx in range(6):
-                k_dft = native_hessian._derivative_kernel_dft_single(
-                    pixel_freq_meshes, derivative_weights, k_idx, is_curvature=True
+            if session is not None:
+                coarse_energy = energy_filter_v200_from_spatial(
+                    session,
+                    original_chunk,
+                    matching_kernel_string=str(
+                        config.get("matching_kernel_string", "3D gaussian conv annular pulse")
+                    ),
+                    radius=float(radius_of_lumen_in_microns),
+                    vessel_wall=float(config.get("vessel_wall_thickness_in_microns", 0.0)),
+                    microns_per_pixel=microns_per_pixel_matlab,
+                    pixels_per_sigma_psf=pixels_per_sigma_psf_at_oct[[1, 2, 0]],
+                    y0=int(y_local.start or 0) + 1,
+                    y1=int(y_local.stop),
+                    x0=int(x_local.start or 0) + 1,
+                    x1=int(x_local.stop),
+                    z0=int(z_local.start or 0) + 1,
+                    z1=int(z_local.stop),
+                    gaussian_to_ideal_ratio=float(config["gaussian_to_ideal_ratio"]),
+                    spherical_to_annular_ratio=float(config["spherical_to_annular_ratio"]),
+                    scales_per_octave=float(config.get("scales_per_octave", 1.5)),
                 )
-                full_ifft = native_hessian._ifftn_matlab_symmetric(k_dft * filtered_chunk_dft)
-                curvatures_local[k_idx] = full_ifft[y_local, x_local, z_local]
-                del k_dft, full_ifft
-
-            gradient_local = np.empty((3, *coarse_shape), dtype=np.float64, order="F")
-            for k_idx in range(3):
-                k_dft = native_hessian._derivative_kernel_dft_single(
-                    pixel_freq_meshes, derivative_weights, k_idx, is_curvature=False
+            else:
+                assert chunk_dft is not None
+                assert pixel_freq_meshes is not None
+                matching_kernel_dft, derivative_weights = native_hessian._matching_kernel_dft(
+                    pixel_freq_meshes,
+                    radius_of_lumen_in_microns=radius_of_lumen_in_microns,
+                    microns_per_pixel=microns_per_pixel_matlab,
+                    pixels_per_sigma_psf=pixels_per_sigma_psf_at_oct[[1, 2, 0]],
+                    gaussian_to_ideal_ratio=float(config["gaussian_to_ideal_ratio"]),
+                    spherical_to_annular_ratio=float(config["spherical_to_annular_ratio"]),
                 )
-                full_ifft = native_hessian._ifftn_matlab_symmetric(k_dft * filtered_chunk_dft)
-                gradient_local[k_idx] = full_ifft[y_local, x_local, z_local]
-                del k_dft, full_ifft
 
-            # Explicitly delete DFT products
-            del filtered_chunk_dft
+                filtered_chunk_dft = matching_kernel_dft * chunk_dft
+                del matching_kernel_dft
 
-            laplacian_chunk = curvatures_local[0] + curvatures_local[1] + curvatures_local[2]
-            valid_voxels = laplacian_chunk < 0
-            coarse_energy = np.full(coarse_shape, np.inf, dtype=np.float64)
+                # All intermediates are [Y, X, Z] with Fortran order
+                # Compute derivative kernels one-by-one to minimize peak memory
+                curvatures_local = np.empty((6, *coarse_shape), dtype=np.float64, order="F")
+                for k_idx in range(6):
+                    k_dft = native_hessian._derivative_kernel_dft_single(
+                        pixel_freq_meshes, derivative_weights, k_idx, is_curvature=True
+                    )
+                    full_ifft = native_hessian._ifftn_matlab_symmetric(k_dft * filtered_chunk_dft)
+                    curvatures_local[k_idx] = full_ifft[y_local, x_local, z_local]
+                    del k_dft, full_ifft
 
-            if np.any(valid_voxels):
-                grad_valid = np.stack(
-                    [
-                        gradient_local[0][valid_voxels],
-                        gradient_local[1][valid_voxels],
-                        gradient_local[2][valid_voxels],
-                    ],
-                    axis=1,
-                )
-                curvatures_valid = np.stack(
-                    [
-                        curvatures_local[0][valid_voxels],
-                        curvatures_local[1][valid_voxels],
-                        curvatures_local[2][valid_voxels],
-                        curvatures_local[3][valid_voxels],
-                        curvatures_local[4][valid_voxels],
-                        curvatures_local[5][valid_voxels],
-                    ],
-                    axis=1,
-                )
-                energy_valid = compute_principal_energy(
-                    grad_valid,
-                    curvatures_valid,
-                    energy_sign=float(config.get("energy_sign", -1.0)),
-                )
-                coarse_energy[valid_voxels] = energy_valid
+                gradient_local = np.empty((3, *coarse_shape), dtype=np.float64, order="F")
+                for k_idx in range(3):
+                    k_dft = native_hessian._derivative_kernel_dft_single(
+                        pixel_freq_meshes, derivative_weights, k_idx, is_curvature=False
+                    )
+                    full_ifft = native_hessian._ifftn_matlab_symmetric(k_dft * filtered_chunk_dft)
+                    gradient_local[k_idx] = full_ifft[y_local, x_local, z_local]
+                    del k_dft, full_ifft
 
-                del grad_valid, curvatures_valid, energy_valid
-            # Free local cropped arrays
-            del curvatures_local, gradient_local
+                del filtered_chunk_dft
+
+                laplacian_chunk = curvatures_local[0] + curvatures_local[1] + curvatures_local[2]
+                valid_voxels = laplacian_chunk < 0
+                coarse_energy = np.full(coarse_shape, np.inf, dtype=np.float64)
+
+                if np.any(valid_voxels):
+                    grad_valid = np.stack(
+                        [
+                            gradient_local[0][valid_voxels],
+                            gradient_local[1][valid_voxels],
+                            gradient_local[2][valid_voxels],
+                        ],
+                        axis=1,
+                    )
+                    curvatures_valid = np.stack(
+                        [
+                            curvatures_local[0][valid_voxels],
+                            curvatures_local[1][valid_voxels],
+                            curvatures_local[2][valid_voxels],
+                            curvatures_local[3][valid_voxels],
+                            curvatures_local[4][valid_voxels],
+                            curvatures_local[5][valid_voxels],
+                        ],
+                        axis=1,
+                    )
+                    energy_valid = compute_principal_energy(
+                        grad_valid,
+                        curvatures_valid,
+                        energy_sign=float(config.get("energy_sign", -1.0)),
+                    )
+                    coarse_energy[valid_voxels] = energy_valid
+
+                    del grad_valid, curvatures_valid, energy_valid
+                del curvatures_local, gradient_local
 
             coarse_energy[~np.isfinite(coarse_energy)] = np.inf
             coarse_energy[coarse_energy >= 0] = np.inf

--- a/slavv_python/pipeline/energy/matlab_get_energy_v202_chunked.py
+++ b/slavv_python/pipeline/energy/matlab_get_energy_v202_chunked.py
@@ -32,7 +32,7 @@ from slavv_python.pipeline.energy import matlab_energy_filter_v200 as native_hes
 from slavv_python.pipeline.energy.matlab_engine_backend import (
     ensure_matlab_engine_float_backend_ready,
 )
-from slavv_python.pipeline.energy.matlab_engine_host import energy_filter_v200_from_spatial
+from slavv_python.pipeline.energy.matlab_engine_host import energy_chunk_v202_from_spatial
 from slavv_python.pipeline.energy.matlab_principal_energy import compute_principal_energy
 
 if TYPE_CHECKING:
@@ -547,55 +547,66 @@ def compute_exact_parity_energy_single_octave(
         l_start_x = x_local.start or 0
         l_start_z = z_local.start or 0
 
-        mesh_y = _matlab_zero_based_linspace(off_y, stride_y, w_count_y, l_start_y)
-        mesh_x = _matlab_zero_based_linspace(off_x, stride_x, w_count_x, l_start_x)
-        mesh_z = _matlab_zero_based_linspace(off_z, stride_z, w_count_z, l_start_z)
-
-        # [Y, X, Z] mesh for interpolation (sparse to save memory)
-        mesh_coords: tuple[np.ndarray, np.ndarray, np.ndarray] = np.meshgrid(
-            mesh_y, mesh_x, mesh_z, indexing="ij", sparse=True
-        )
-        coords_grid = mesh_coords
-
-        # Accumulators in [Y, X, Z] order with Fortran contiguity
-        chunk_best_energy: np.ndarray = np.full(
-            (w_count_y, w_count_x, w_count_z), 0.0, dtype=np.float64, order="F"
-        )
-        chunk_best_scale_sub_idx: np.ndarray = np.full(
-            (w_count_y, w_count_x, w_count_z), -1, dtype=np.int16, order="F"
-        )
-
-        for s_sub_idx, s_idx in enumerate(scale_indices_at_octave):
-            radius_of_lumen_in_microns = lumen_radius_microns[s_idx]
+        chunk_best_energy: np.ndarray
+        chunk_best_scale_sub_idx: np.ndarray
+        if session is not None:
             pixels_per_sigma_psf_at_oct = pixels_per_sigma_PSF / rf
-            coarse_shape = (
-                y_local.stop - y_local.start,
-                x_local.stop - x_local.start,
-                z_local.stop - z_local.start,
+            energy_yxz, scale_1based = energy_chunk_v202_from_spatial(
+                session,
+                original_chunk,
+                matching_kernel_string=str(
+                    config.get("matching_kernel_string", "3D gaussian conv annular pulse")
+                ),
+                radii=np.asarray(lumen_radius_microns[scale_indices_at_octave], dtype=np.float64),
+                vessel_wall=float(config.get("vessel_wall_thickness_in_microns", 0.0)),
+                microns_per_pixel=microns_per_pixel_matlab,
+                pixels_per_sigma_psf=pixels_per_sigma_psf_at_oct[[1, 2, 0]],
+                y0=int(y_local.start or 0) + 1,
+                y1=int(y_local.stop),
+                x0=int(x_local.start or 0) + 1,
+                x1=int(x_local.stop),
+                z0=int(z_local.start or 0) + 1,
+                z1=int(z_local.stop),
+                y_offset=off_y,
+                x_offset=off_x,
+                z_offset=off_z,
+                y_write_count=w_count_y,
+                x_write_count=w_count_x,
+                z_write_count=w_count_z,
+                rf_y=stride_y,
+                rf_x=stride_x,
+                rf_z=stride_z,
+                gaussian_to_ideal_ratio=float(config["gaussian_to_ideal_ratio"]),
+                spherical_to_annular_ratio=float(config["spherical_to_annular_ratio"]),
+                scales_per_octave=float(config.get("scales_per_octave", 1.5)),
+            )
+            chunk_best_energy = np.asfortranarray(np.asarray(energy_yxz, dtype=np.float64))
+            chunk_best_scale_sub_idx = np.asfortranarray(
+                np.asarray(scale_1based, dtype=np.float64).astype(np.int16) - 1
+            )
+        else:
+            mesh_y = _matlab_zero_based_linspace(off_y, stride_y, w_count_y, l_start_y)
+            mesh_x = _matlab_zero_based_linspace(off_x, stride_x, w_count_x, l_start_x)
+            mesh_z = _matlab_zero_based_linspace(off_z, stride_z, w_count_z, l_start_z)
+            mesh_coords: tuple[np.ndarray, np.ndarray, np.ndarray] = np.meshgrid(
+                mesh_y, mesh_x, mesh_z, indexing="ij", sparse=True
+            )
+            coords_grid = mesh_coords
+            chunk_best_energy = np.full(
+                (w_count_y, w_count_x, w_count_z), 0.0, dtype=np.float64, order="F"
+            )
+            chunk_best_scale_sub_idx = np.full(
+                (w_count_y, w_count_x, w_count_z), -1, dtype=np.int16, order="F"
             )
 
-            if session is not None:
-                coarse_energy = energy_filter_v200_from_spatial(
-                    session,
-                    original_chunk,
-                    matching_kernel_string=str(
-                        config.get("matching_kernel_string", "3D gaussian conv annular pulse")
-                    ),
-                    radius=float(radius_of_lumen_in_microns),
-                    vessel_wall=float(config.get("vessel_wall_thickness_in_microns", 0.0)),
-                    microns_per_pixel=microns_per_pixel_matlab,
-                    pixels_per_sigma_psf=pixels_per_sigma_psf_at_oct[[1, 2, 0]],
-                    y0=int(y_local.start or 0) + 1,
-                    y1=int(y_local.stop),
-                    x0=int(x_local.start or 0) + 1,
-                    x1=int(x_local.stop),
-                    z0=int(z_local.start or 0) + 1,
-                    z1=int(z_local.stop),
-                    gaussian_to_ideal_ratio=float(config["gaussian_to_ideal_ratio"]),
-                    spherical_to_annular_ratio=float(config["spherical_to_annular_ratio"]),
-                    scales_per_octave=float(config.get("scales_per_octave", 1.5)),
+            for s_sub_idx, s_idx in enumerate(scale_indices_at_octave):
+                radius_of_lumen_in_microns = lumen_radius_microns[s_idx]
+                pixels_per_sigma_psf_at_oct = pixels_per_sigma_PSF / rf
+                coarse_shape = (
+                    y_local.stop - y_local.start,
+                    x_local.stop - x_local.start,
+                    z_local.stop - z_local.start,
                 )
-            else:
                 assert chunk_dft is not None
                 assert pixel_freq_meshes is not None
                 matching_kernel_dft, derivative_weights = native_hessian._matching_kernel_dft(
@@ -666,22 +677,22 @@ def compute_exact_parity_energy_single_octave(
                     del grad_valid, curvatures_valid, energy_valid
                 del curvatures_local, gradient_local
 
-            coarse_energy[~np.isfinite(coarse_energy)] = np.inf
-            coarse_energy[coarse_energy >= 0] = np.inf
+                coarse_energy[~np.isfinite(coarse_energy)] = np.inf
+                coarse_energy[coarse_energy >= 0] = np.inf
 
-            upsampled = _interp3_matlab_linear_inf(coarse_energy, coords_grid)
-            del coarse_energy
-            upsampled[(~np.isfinite(upsampled)) | (upsampled >= 0)] = 0.0
+                upsampled = _interp3_matlab_linear_inf(coarse_energy, coords_grid)
+                del coarse_energy
+                upsampled[(~np.isfinite(upsampled)) | (upsampled >= 0)] = 0.0
 
-            if s_sub_idx == 0:
-                chunk_best_energy = upsampled
-                chunk_best_scale_sub_idx = np.zeros_like(chunk_best_scale_sub_idx)
-            else:
-                is_better = upsampled < chunk_best_energy
-                chunk_best_energy = np.where(is_better, upsampled, chunk_best_energy)
-                chunk_best_scale_sub_idx[is_better] = s_sub_idx
+                if s_sub_idx == 0:
+                    chunk_best_energy = upsampled
+                    chunk_best_scale_sub_idx = np.zeros_like(chunk_best_scale_sub_idx)
+                else:
+                    is_better = upsampled < chunk_best_energy
+                    chunk_best_energy = np.where(is_better, upsampled, chunk_best_energy)
+                    chunk_best_scale_sub_idx[is_better] = s_sub_idx
 
-            del upsampled
+                del upsampled
 
         # Energy and scale are accumulated in [Y, X, Z] order internally.
         # We transpose them back to [Z, Y, X] to match the master volume's axis order.

--- a/slavv_python/pipeline/energy/provenance.py
+++ b/slavv_python/pipeline/energy/provenance.py
@@ -3,12 +3,28 @@
 from __future__ import annotations
 
 CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN = "python_native_hessian"
+# Stretch Approach A: MATLAB-engine float path under Python orchestration.
+STRETCH_ENGINE_ENERGY_ORIGIN = "matlab_engine_hessian"
 # "hessian" is a legacy provenance label stored in older checkpoints; treat as equivalent.
 EXACT_COMPATIBLE_ENERGY_ORIGINS = frozenset({CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN, "hessian"})
+STRETCH_COMPATIBLE_ENERGY_ORIGINS = frozenset({STRETCH_ENGINE_ENERGY_ORIGIN})
+
+ENERGY_FLOAT_BACKEND_NUMPY = "numpy"
+ENERGY_FLOAT_BACKEND_MATLAB_ENGINE = "matlab_engine"
+ENERGY_FLOAT_BACKENDS = frozenset({ENERGY_FLOAT_BACKEND_NUMPY, ENERGY_FLOAT_BACKEND_MATLAB_ENGINE})
 
 
-def energy_origin_for_method(energy_method: str) -> str:
+def energy_origin_for_method(
+    energy_method: str,
+    *,
+    energy_float_backend: str = ENERGY_FLOAT_BACKEND_NUMPY,
+) -> str:
     """Return the persisted provenance label for one energy backend."""
+    backend = str(energy_float_backend or ENERGY_FLOAT_BACKEND_NUMPY).strip().lower()
+    if backend == ENERGY_FLOAT_BACKEND_MATLAB_ENGINE:
+        if energy_method != "hessian":
+            raise ValueError("energy_float_backend=matlab_engine requires energy_method=hessian")
+        return STRETCH_ENGINE_ENERGY_ORIGIN
     if energy_method == "hessian":
         return CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN
     return f"python_{energy_method}"
@@ -17,6 +33,38 @@ def energy_origin_for_method(energy_method: str) -> str:
 def is_exact_compatible_energy_origin(origin: object) -> bool:
     """Return whether an energy provenance is accepted on the exact route."""
     return isinstance(origin, str) and origin in EXACT_COMPATIBLE_ENERGY_ORIGINS
+
+
+def is_stretch_compatible_energy_origin(origin: object) -> bool:
+    """Return whether an energy provenance is accepted for stretch Watershed."""
+    return isinstance(origin, str) and origin in STRETCH_COMPATIBLE_ENERGY_ORIGINS
+
+
+def is_watershed_allowed_energy_origin(
+    origin: object,
+    *,
+    stretch_mode: bool = False,
+) -> bool:
+    """Exact-route Watershed allowlist; stretch mode adds engine origin only."""
+    if is_exact_compatible_energy_origin(origin):
+        return True
+    return bool(stretch_mode) and is_stretch_compatible_energy_origin(origin)
+
+
+def refuse_mixed_stretch_energy_origins(origins: set[str] | frozenset[str]) -> None:
+    """Stretch proofs reject mixed NumPy/engine Energy provenance (KTD7)."""
+    cleaned = {str(item) for item in origins if item}
+    has_native = bool(cleaned & EXACT_COMPATIBLE_ENERGY_ORIGINS)
+    has_engine = bool(cleaned & STRETCH_COMPATIBLE_ENERGY_ORIGINS)
+    if has_native and has_engine:
+        raise ValueError(
+            "mixed Energy origins in stretch proof: "
+            f"{sorted(cleaned)}; refuse NumPy+engine mix (KTD7)"
+        )
+    if has_native and not has_engine:
+        raise ValueError(
+            f"stretch proof requires matlab_engine_hessian origin; found {sorted(cleaned)}"
+        )
 
 
 def exact_route_gate_description() -> str:
@@ -34,9 +82,17 @@ def exact_compatible_energy_origins_text() -> str:
 
 __all__ = [
     "CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN",
+    "ENERGY_FLOAT_BACKENDS",
+    "ENERGY_FLOAT_BACKEND_MATLAB_ENGINE",
+    "ENERGY_FLOAT_BACKEND_NUMPY",
     "EXACT_COMPATIBLE_ENERGY_ORIGINS",
+    "STRETCH_COMPATIBLE_ENERGY_ORIGINS",
+    "STRETCH_ENGINE_ENERGY_ORIGIN",
     "energy_origin_for_method",
     "exact_compatible_energy_origins_text",
     "exact_route_gate_description",
     "is_exact_compatible_energy_origin",
+    "is_stretch_compatible_energy_origin",
+    "is_watershed_allowed_energy_origin",
+    "refuse_mixed_stretch_energy_origins",
 ]

--- a/slavv_python/pipeline/energy/resumable.py
+++ b/slavv_python/pipeline/energy/resumable.py
@@ -424,7 +424,10 @@ def calculate_energy_field_resumable(
         pixels_per_sigma_PSF=config["pixels_per_sigma_PSF"],
         microns_per_sigma_PSF=config["microns_per_sigma_PSF"],
         energy_sign=config["energy_sign"],
-        energy_origin=energy_origin_for_method(str(config["energy_method"])),
+        energy_origin=energy_origin_for_method(
+            str(config["energy_method"]),
+            energy_float_backend=str(config.get("energy_float_backend", "numpy")),
+        ),
     )
     if returned_energy_4d is not None:
         result.extra["energy_4d"] = returned_energy_4d

--- a/slavv_python/pipeline/energy/resumable.py
+++ b/slavv_python/pipeline/energy/resumable.py
@@ -42,17 +42,24 @@ if TYPE_CHECKING:
     from slavv_python.engine.state import StageController
 
 
+def _jsonable_config_value(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
 def _config_hash(config: dict[str, Any]) -> str:
+    """Hash durable Energy config; skip runtime handles such as the engine session."""
+    params = {
+        key: _jsonable_config_value(value)
+        for key, value in config.items()
+        if key not in {"image_shape", "image_dtype"} and not str(key).startswith("_")
+    }
     return hashlib.sha256(
         json.dumps(
-            {
-                "params": {
-                    k: v.tolist() if isinstance(v, np.ndarray) else v
-                    for k, v in config.items()
-                    if k not in {"image_shape", "image_dtype"}
-                },
-                "shape": list(config["image_shape"]),
-            },
+            {"params": params, "shape": list(config["image_shape"])},
             sort_keys=True,
         ).encode("utf-8")
     ).hexdigest()

--- a/slavv_python/utils/validation.py
+++ b/slavv_python/utils/validation.py
@@ -150,6 +150,17 @@ def validate_parameters(params: dict[str, Any]) -> dict[str, Any]:
             "energy_method must be 'hessian', 'frangi', 'sato', "
             "'simpleitk_objectness', or 'cupy_hessian'"
         )
+    validated["energy_float_backend"] = (
+        str(params.get("energy_float_backend", "numpy")).strip().lower()
+    )
+    if validated["energy_float_backend"] not in ("numpy", "matlab_engine"):
+        raise ValueError("energy_float_backend must be 'numpy' or 'matlab_engine'")
+    if (
+        validated["energy_float_backend"] == "matlab_engine"
+        and validated["energy_method"] != "hessian"
+    ):
+        raise ValueError("energy_float_backend=matlab_engine requires energy_method=hessian")
+    validated["stretch_zero_tolerance"] = bool(params.get("stretch_zero_tolerance", False))
     validated["direction_method"] = params.get("direction_method", "hessian")
     if validated["direction_method"] not in ("hessian", "uniform"):
         raise ValueError("direction_method must be 'hessian' or 'uniform'")

--- a/tests/unit/parity/test_launch_prepare.py
+++ b/tests/unit/parity/test_launch_prepare.py
@@ -75,12 +75,15 @@ def test_prepare_detached_exact_run_launch_runs_foreground_probe(tmp_path, monke
         skip_preflight=False,
         skip_foreground_probe=False,
         n_jobs=1,
+        energy_float_backend="matlab_engine",
     )
 
     assert probe_calls
     assert "--stop-after" in foreground
     assert foreground[foreground.index("--stop-after") + 1] == "preprocess"
+    assert "--energy-float-backend" not in foreground
     assert detached[detached.index("--stop-after") + 1] == "energy"
+    assert detached[detached.index("--energy-float-backend") + 1] == "matlab_engine"
 
 
 @pytest.mark.unit

--- a/tests/unit/parity/test_mkl_spike_does_not_replace_engine.py
+++ b/tests/unit/parity/test_mkl_spike_does_not_replace_engine.py
@@ -1,0 +1,10 @@
+"""Policy: MKL spike cannot replace Approach A / mark stretch complete (U7)."""
+
+from __future__ import annotations
+
+from slavv_python.analytics.parity.proof.stretch import mkl_spike_cannot_complete_stretch
+
+
+def test_mkl_pass_does_not_mean_stretch_complete() -> None:
+    assert mkl_spike_cannot_complete_stretch(mkl_bit_equal=True) is True
+    assert mkl_spike_cannot_complete_stretch(mkl_bit_equal=False) is True

--- a/tests/unit/parity/test_parity_experiment_comprehensive.py
+++ b/tests/unit/parity/test_parity_experiment_comprehensive.py
@@ -224,10 +224,13 @@ def test_build_parser_commands():
             "energy",
             "--n-jobs",
             "4",
+            "--energy-float-backend",
+            "matlab_engine",
         ]
     )
     assert args.command == "launch-exact-run"
     assert args.n_jobs == 4
+    assert args.energy_float_backend == "matlab_engine"
 
     args = parser.parse_args(["status-exact-run", "--run-dir", "dst"])
     assert args.command == "status-exact-run"

--- a/tests/unit/parity/test_stretch_crop_energy_strict_floats.py
+++ b/tests/unit/parity/test_stretch_crop_energy_strict_floats.py
@@ -1,0 +1,56 @@
+"""Tests for stretch crop Energy --strict-floats unlock emission (U4)."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+from slavv_python.analytics.parity.proof.stretch import (
+    StretchFieldSet,
+    emit_stretch_energy_unlock_if_eligible,
+    load_stretch_unlock,
+)
+
+
+def test_ulp_drift_style_fail_does_not_emit_unlock(tmp_path: Path) -> None:
+    path = emit_stretch_energy_unlock_if_eligible(
+        dest_run_root=tmp_path / "dest",
+        oracle_root=tmp_path / "oracle",
+        proof_path=tmp_path / "proof.json",
+        report={"passed": False, "energy_float_gate": {"passed": False, "strict_floats": True}},
+        strict_floats=True,
+    )
+    assert path is None
+
+
+def test_allclose_green_without_strict_does_not_emit_unlock(tmp_path: Path) -> None:
+    path = emit_stretch_energy_unlock_if_eligible(
+        dest_run_root=tmp_path / "dest",
+        oracle_root=tmp_path / "oracle",
+        proof_path=tmp_path / "proof.json",
+        report={"passed": True, "stage_summaries": {"energy": {"passed": True}}},
+        strict_floats=False,
+    )
+    assert path is None
+
+
+def test_strict_green_emits_energy_unlock(tmp_path: Path) -> None:
+    dest = tmp_path / "dest"
+    oracle = tmp_path / "oracle"
+    proof = tmp_path / "exact_proof_energy.json"
+    dest.mkdir()
+    path = emit_stretch_energy_unlock_if_eligible(
+        dest_run_root=dest,
+        oracle_root=oracle,
+        proof_path=proof,
+        report={
+            "passed": True,
+            "stage_summaries": {"energy": {"passed": True}},
+            "energy_float_gate": {"passed": True, "strict_floats": True},
+        },
+        strict_floats=True,
+    )
+    assert path is not None
+    assert path.is_file()
+    token = load_stretch_unlock(path)
+    assert token.field_set == StretchFieldSet.ENERGY
+    assert token.strict_floats is True

--- a/tests/unit/parity/test_stretch_discrete_strict_field.py
+++ b/tests/unit/parity/test_stretch_discrete_strict_field.py
@@ -1,0 +1,69 @@
+"""Tests for stretch discrete strict-field classification (U5)."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+from slavv_python.analytics.parity.proof.stretch import (
+    ClassifiedStretchFailure,
+    StretchFieldSet,
+    StretchStatus,
+    evaluate_stretch_discrete_connections,
+    expand_unlock_with_discrete,
+    load_stretch_unlock,
+    write_stretch_unlock,
+)
+
+
+def test_connections_mismatch_is_incomplete_discrete(tmp_path: Path) -> None:
+    write_stretch_unlock(
+        tmp_path / "unlock.json",
+        field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "crop",
+        oracle_root=tmp_path / "oracle",
+        proof_path=tmp_path / "proof.json",
+    )
+    result = evaluate_stretch_discrete_connections(
+        matlab_connections=[[1, 2], [3, 4]],
+        python_connections=[[1, 2], [4, 3]],
+        energy_unlock_present=True,
+    )
+    assert isinstance(result, ClassifiedStretchFailure)
+    assert result.status == StretchStatus.INCOMPLETE_DISCRETE
+
+
+def test_exact_connections_expand_unlock(tmp_path: Path) -> None:
+    unlock = tmp_path / "unlock.json"
+    write_stretch_unlock(
+        unlock,
+        field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "crop",
+        oracle_root=tmp_path / "oracle",
+        proof_path=tmp_path / "proof.json",
+    )
+    result = evaluate_stretch_discrete_connections(
+        matlab_connections=[[1, 2], [3, 4]],
+        python_connections=[[1, 2], [3, 4]],
+        energy_unlock_present=True,
+    )
+    assert result == StretchStatus.STRETCH_COMPLETE
+    expand_unlock_with_discrete(
+        unlock,
+        dest_run_root=tmp_path / "crop",
+        oracle_root=tmp_path / "oracle",
+        proof_path=tmp_path / "discrete_proof.json",
+    )
+    assert load_stretch_unlock(unlock).field_set == StretchFieldSet.ENERGY_AND_DISCRETE
+
+
+def test_adr0012_ownership_alone_does_not_expand_without_exact_connections(
+    tmp_path: Path,
+) -> None:
+    """Ownership-map green is not discrete stretch complete — need exact connections."""
+    result = evaluate_stretch_discrete_connections(
+        matlab_connections=[[1, 2]],
+        python_connections=[[2, 1]],
+        energy_unlock_present=True,
+    )
+    assert isinstance(result, ClassifiedStretchFailure)
+    assert result.status == StretchStatus.INCOMPLETE_DISCRETE

--- a/tests/unit/parity/test_stretch_full_volume_gate.py
+++ b/tests/unit/parity/test_stretch_full_volume_gate.py
@@ -1,0 +1,68 @@
+"""Tests for full-volume stretch unlock gate (U6)."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+from slavv_python.analytics.parity.proof.stretch import (
+    PHASE1_CLAIM_RUN_NAME,
+    StretchFieldSet,
+    StretchStatus,
+    gate_full_stretch_entry,
+    write_stretch_status,
+    write_stretch_unlock,
+)
+
+
+def test_full_entry_without_unlock_refused(tmp_path: Path) -> None:
+    decision = gate_full_stretch_entry(
+        unlock_path=tmp_path / "missing.json",
+        requested_field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "full_stretch_v1",
+        oracle_root=tmp_path / "oracle",
+    )
+    assert decision.allowed is False
+    assert decision.status == StretchStatus.FULL_REFUSED
+
+
+def test_energy_only_unlock_cannot_claim_full_discrete(tmp_path: Path) -> None:
+    oracle = tmp_path / "oracle"
+    unlock = tmp_path / "unlock.json"
+    write_stretch_unlock(
+        unlock,
+        field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "crop",
+        oracle_root=oracle,
+        proof_path=tmp_path / "proof.json",
+    )
+    decision = gate_full_stretch_entry(
+        unlock_path=unlock,
+        requested_field_set=StretchFieldSet.ENERGY_AND_DISCRETE,
+        dest_run_root=tmp_path / "full_stretch_v1",
+        oracle_root=oracle,
+    )
+    assert decision.allowed is False
+
+
+def test_completing_stretch_status_does_not_flip_one_truth(tmp_path: Path) -> None:
+    findings = tmp_path / "EXACT_PROOF_FINDINGS.md"
+    closed = "Certification is CLOSED on canonical_full_v18\n"
+    findings.write_text(closed, encoding="utf-8")
+    write_stretch_status(
+        tmp_path / "stretch_status.json",
+        status=StretchStatus.STRETCH_COMPLETE,
+        findings_path=findings,
+        note="full green",
+    )
+    assert findings.read_text(encoding="utf-8") == closed
+
+
+def test_refuse_overwrite_phase1_claim_root(tmp_path: Path) -> None:
+    decision = gate_full_stretch_entry(
+        unlock_path=tmp_path / "unlock.json",
+        requested_field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / PHASE1_CLAIM_RUN_NAME,
+        oracle_root=tmp_path / "oracle",
+    )
+    assert decision.allowed is False
+    assert PHASE1_CLAIM_RUN_NAME in decision.reason

--- a/tests/unit/parity/test_stretch_unlock_gate.py
+++ b/tests/unit/parity/test_stretch_unlock_gate.py
@@ -1,0 +1,114 @@
+"""Characterization and gate tests for stretch unlock / status (U1)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from slavv_python.analytics.parity.proof.stretch import (
+    StretchFailureClass,
+    StretchFieldSet,
+    StretchStatus,
+    classify_stretch_failure,
+    gate_full_stretch_entry,
+    load_stretch_unlock,
+    write_stretch_status,
+    write_stretch_unlock,
+)
+
+ONE_TRUTH_CLOSED_SNIPPET = (
+    "## ONE TRUTH — Phase 1 parity (validated from disk)\n\n"
+    "> **Answer:** Phase 1 exact-route **Certification is CLOSED** on full `180709_E`.\n"
+)
+
+
+def test_full_stretch_entry_without_unlock_refuses(tmp_path: Path) -> None:
+    decision = gate_full_stretch_entry(
+        unlock_path=tmp_path / "missing_unlock.json",
+        requested_field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "full_stretch",
+        oracle_root=tmp_path / "oracle",
+    )
+    assert decision.allowed is False
+    assert decision.status == StretchStatus.FULL_REFUSED
+
+
+def test_energy_only_unlock_does_not_authorize_discrete_full(tmp_path: Path) -> None:
+    unlock_path = tmp_path / "unlock.json"
+    write_stretch_unlock(
+        unlock_path,
+        field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "crop_dest",
+        oracle_root=tmp_path / "oracle",
+        proof_path=tmp_path / "exact_proof_energy.json",
+    )
+    decision = gate_full_stretch_entry(
+        unlock_path=unlock_path,
+        requested_field_set=StretchFieldSet.ENERGY_AND_DISCRETE,
+        dest_run_root=tmp_path / "full_stretch",
+        oracle_root=tmp_path / "oracle",
+    )
+    assert decision.allowed is False
+    assert decision.status == StretchStatus.FULL_REFUSED
+    assert "discrete" in decision.reason.lower()
+
+
+def test_status_writer_does_not_mutate_one_truth_closed(tmp_path: Path) -> None:
+    findings = tmp_path / "EXACT_PROOF_FINDINGS.md"
+    findings.write_text(ONE_TRUTH_CLOSED_SNIPPET, encoding="utf-8")
+    status_path = tmp_path / "stretch_status.json"
+    write_stretch_status(
+        status_path,
+        status=StretchStatus.CROP_ENERGY_PASSED,
+        findings_path=findings,
+        note="crop energy unlocked",
+    )
+    after = findings.read_text(encoding="utf-8")
+    assert "Certification is CLOSED" in after
+    assert after == ONE_TRUTH_CLOSED_SNIPPET
+    payload = status_path.read_text(encoding="utf-8")
+    assert StretchStatus.CROP_ENERGY_PASSED.value in payload
+
+
+def test_infra_failure_is_not_blocked_float_path() -> None:
+    classified = classify_stretch_failure(
+        StretchFailureClass.INFRA,
+        detail="MATLAB engine license unavailable",
+    )
+    assert classified.status == StretchStatus.INCOMPLETE_INFRA
+    assert classified.status != StretchStatus.BLOCKED_FLOAT_PATH
+
+
+def test_energy_unlock_authorizes_matching_energy_full(tmp_path: Path) -> None:
+    oracle = tmp_path / "oracle"
+    unlock_path = tmp_path / "unlock.json"
+    write_stretch_unlock(
+        unlock_path,
+        field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "crop_dest",
+        oracle_root=oracle,
+        proof_path=tmp_path / "exact_proof_energy.json",
+    )
+    decision = gate_full_stretch_entry(
+        unlock_path=unlock_path,
+        requested_field_set=StretchFieldSet.ENERGY,
+        dest_run_root=tmp_path / "full_stretch",
+        oracle_root=oracle,
+    )
+    assert decision.allowed is True
+    assert load_stretch_unlock(unlock_path).field_set == StretchFieldSet.ENERGY
+
+
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        (StretchFailureClass.FLOAT_PATH, StretchStatus.BLOCKED_FLOAT_PATH),
+        (StretchFailureClass.DISCRETE, StretchStatus.INCOMPLETE_DISCRETE),
+        (StretchFailureClass.AT_FULL, StretchStatus.INCOMPLETE_AT_FULL),
+    ],
+)
+def test_failure_class_taxonomy(
+    failure: StretchFailureClass, expected: StretchStatus
+) -> None:
+    assert classify_stretch_failure(failure, detail="x").status == expected

--- a/tests/unit/parity/test_stretch_unlock_gate.py
+++ b/tests/unit/parity/test_stretch_unlock_gate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path  # noqa: TC003
 
 import pytest
 
@@ -108,7 +108,5 @@ def test_energy_unlock_authorizes_matching_energy_full(tmp_path: Path) -> None:
         (StretchFailureClass.AT_FULL, StretchStatus.INCOMPLETE_AT_FULL),
     ],
 )
-def test_failure_class_taxonomy(
-    failure: StretchFailureClass, expected: StretchStatus
-) -> None:
+def test_failure_class_taxonomy(failure: StretchFailureClass, expected: StretchStatus) -> None:
     assert classify_stretch_failure(failure, detail="x").status == expected

--- a/tests/unit/pipeline/energy/test_matlab_engine_backend.py
+++ b/tests/unit/pipeline/energy/test_matlab_engine_backend.py
@@ -1,0 +1,62 @@
+"""Unit tests for MATLAB-engine Energy adapter (U2)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    MatlabEngineInfraError,
+    MatlabEnginePolicyError,
+    MatlabEngineSession,
+    matlab_engine_importable,
+    numpy_to_matlab_double,
+    refuse_matlab_only_energy_checkpoint_as_stretch_success,
+    verify_matlab_engine_prerequisites,
+)
+
+
+def test_engine_missing_raises_infra_not_silent_numpy() -> None:
+    """When engine cannot start, surface incomplete_infra — no stretch fallback."""
+    if matlab_engine_importable():
+        pytest.skip("matlab.engine importable on this interpreter")
+    with pytest.raises(
+        MatlabEngineInfraError,
+        match=r"incomplete_infra|not importable|supports Python",
+    ):
+        verify_matlab_engine_prerequisites()
+
+
+def test_refuse_matlab_only_energy_as_stretch_success() -> None:
+    with pytest.raises(MatlabEnginePolicyError, match="R6"):
+        refuse_matlab_only_energy_checkpoint_as_stretch_success()
+
+
+def test_session_start_fails_as_infra_on_unsupported_python() -> None:
+    """Repo CI Python (3.12) cannot host R2019a Engine — classify as infra."""
+    with pytest.raises(MatlabEngineInfraError):
+        MatlabEngineSession().start()
+
+
+@pytest.mark.skipif(
+    not matlab_engine_importable(),
+    reason="matlab.engine unavailable; stretch CI skips engine happy-path",
+)
+def test_small_array_roundtrip_preserves_float64_values() -> None:
+    rng = np.random.default_rng(0)
+    original = rng.standard_normal((4, 3, 2), dtype=np.float64)
+    with MatlabEngineSession() as session:
+        restored = session.roundtrip_float64(original)
+    assert restored.shape == original.shape
+    assert restored.dtype == np.float64
+    assert np.array_equal(restored, original)
+
+
+def test_numpy_to_matlab_double_requires_matlab_package() -> None:
+    if matlab_engine_importable():
+        arr = np.arange(6, dtype=np.float64).reshape(2, 3)
+        ml = numpy_to_matlab_double(arr)
+        assert ml is not None
+        return
+    with pytest.raises(MatlabEngineInfraError):
+        numpy_to_matlab_double(np.zeros((2, 2), dtype=np.float64))

--- a/tests/unit/pipeline/energy/test_stretch_energy_origin.py
+++ b/tests/unit/pipeline/energy/test_stretch_energy_origin.py
@@ -1,0 +1,56 @@
+"""Tests for stretch Energy origin stamp and dispatch gates (U3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    MatlabEngineInfraError,
+    ensure_matlab_engine_float_backend_ready,
+)
+from slavv_python.pipeline.energy.provenance import (
+    CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN,
+    STRETCH_ENGINE_ENERGY_ORIGIN,
+    energy_origin_for_method,
+    is_exact_compatible_energy_origin,
+    is_watershed_allowed_energy_origin,
+    refuse_mixed_stretch_energy_origins,
+)
+from slavv_python.utils.validation import validate_parameters
+
+
+def test_default_exact_origin_unchanged() -> None:
+    assert energy_origin_for_method("hessian") == CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN
+    assert is_exact_compatible_energy_origin(CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN)
+
+
+def test_stretch_origin_selected_for_matlab_engine_backend() -> None:
+    assert (
+        energy_origin_for_method("hessian", energy_float_backend="matlab_engine")
+        == STRETCH_ENGINE_ENERGY_ORIGIN
+    )
+
+
+def test_stretch_origin_not_in_phase1_exact_allowlist() -> None:
+    assert not is_exact_compatible_energy_origin(STRETCH_ENGINE_ENERGY_ORIGIN)
+    assert is_watershed_allowed_energy_origin(STRETCH_ENGINE_ENERGY_ORIGIN, stretch_mode=True)
+    assert not is_watershed_allowed_energy_origin(STRETCH_ENGINE_ENERGY_ORIGIN, stretch_mode=False)
+
+
+def test_mixed_origin_rejected_for_stretch() -> None:
+    with pytest.raises(ValueError, match="mixed"):
+        refuse_mixed_stretch_energy_origins(
+            {CANONICAL_NATIVE_EXACT_ENERGY_ORIGIN, STRETCH_ENGINE_ENERGY_ORIGIN}
+        )
+
+
+def test_validate_energy_float_backend_flag() -> None:
+    params = validate_parameters({"energy_float_backend": "matlab_engine"})
+    assert params["energy_float_backend"] == "matlab_engine"
+    with pytest.raises(ValueError, match="energy_float_backend"):
+        validate_parameters({"energy_float_backend": "mkl"})
+
+
+def test_matlab_engine_backend_refuses_numpy_float_body() -> None:
+    with pytest.raises(MatlabEngineInfraError):
+        ensure_matlab_engine_float_backend_ready({"energy_float_backend": "matlab_engine"})

--- a/tests/unit/pipeline/energy/test_stretch_engine_host.py
+++ b/tests/unit/pipeline/energy/test_stretch_engine_host.py
@@ -47,6 +47,48 @@ def test_prepare_config_copies_bound_engine_session() -> None:
     assert _config_hash(config) == hashed
 
 
+def test_engine_chunk_path_calls_interp3_helper_once_per_chunk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[int] = []
+
+    def fake_chunk_helper(
+        session: object,
+        chunk: np.ndarray,
+        **kwargs: object,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        del session
+        calls.append(int(np.asarray(chunk).size))
+        y_w = int(kwargs["y_write_count"])
+        x_w = int(kwargs["x_write_count"])
+        z_w = int(kwargs["z_write_count"])
+        energy = np.full((y_w, x_w, z_w), -1.0, dtype=np.float64)
+        scale = np.ones((y_w, x_w, z_w), dtype=np.float64)
+        return energy, scale
+
+    monkeypatch.setattr(
+        "slavv_python.pipeline.energy.matlab_get_energy_v202_chunked.energy_chunk_v202_from_spatial",
+        fake_chunk_helper,
+    )
+    image = np.zeros((8, 8, 8), dtype=np.float64)
+    params = validate_parameters(
+        {
+            "energy_method": "hessian",
+            "energy_float_backend": "matlab_engine",
+            "comparison_exact_network": True,
+            "n_jobs": 1,
+            "max_voxels_per_node_energy": 1e9,
+        }
+    )
+    params["_stretch_engine_float_body_bound"] = True
+    params["_stretch_engine_session"] = object()
+    config = _prepare_energy_config(image, params)
+    energy, scales, _extra = compute_exact_parity_energy_chunked(image, config)
+    assert calls, "engine path must call stretch_energy_chunk_v202 once per chunk"
+    assert energy.shape == image.shape
+    assert scales.shape == image.shape
+
+
 def test_exact_chunked_refuses_unbound_engine_numpy_body() -> None:
     image = np.zeros((8, 8, 8), dtype=np.float64)
     params = validate_parameters(

--- a/tests/unit/pipeline/energy/test_stretch_engine_host.py
+++ b/tests/unit/pipeline/energy/test_stretch_engine_host.py
@@ -15,6 +15,7 @@ from slavv_python.pipeline.energy.matlab_engine_host import (
 from slavv_python.pipeline.energy.matlab_get_energy_v202_chunked import (
     compute_exact_parity_energy_chunked,
 )
+from slavv_python.pipeline.energy.resumable import _config_hash
 from slavv_python.utils.validation import validate_parameters
 
 
@@ -41,6 +42,9 @@ def test_prepare_config_copies_bound_engine_session() -> None:
     assert config["_stretch_engine_session"] == "sentinel-session"
     assert config["energy_float_backend"] == "matlab_engine"
     assert "scales_per_octave" in config
+    hashed = _config_hash(config)
+    config["_stretch_engine_session"] = object()
+    assert _config_hash(config) == hashed
 
 
 def test_exact_chunked_refuses_unbound_engine_numpy_body() -> None:

--- a/tests/unit/pipeline/energy/test_stretch_engine_host.py
+++ b/tests/unit/pipeline/energy/test_stretch_engine_host.py
@@ -1,0 +1,67 @@
+"""Tests for stretch MATLAB-engine Energy host (Python 3.7 worker + bind)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from slavv_python.pipeline.energy.config import _prepare_energy_config
+from slavv_python.pipeline.energy.matlab_engine_backend import MatlabEngineInfraError
+from slavv_python.pipeline.energy.matlab_engine_host import (
+    STRETCH_PY37_ENV,
+    resolve_python37_executable,
+    stretch_engine_float_body_session,
+)
+from slavv_python.pipeline.energy.matlab_get_energy_v202_chunked import (
+    compute_exact_parity_energy_chunked,
+)
+from slavv_python.utils.validation import validate_parameters
+
+
+def test_numpy_backend_session_is_noop() -> None:
+    config = {"energy_float_backend": "numpy"}
+    with stretch_engine_float_body_session(config) as bound:
+        assert bound is config
+        assert bound.get("_stretch_engine_float_body_bound") is not True
+
+
+def test_prepare_config_copies_bound_engine_session() -> None:
+    image = np.zeros((4, 4, 4), dtype=np.float64)
+    params = validate_parameters(
+        {
+            "energy_method": "hessian",
+            "energy_float_backend": "matlab_engine",
+            "comparison_exact_network": True,
+        }
+    )
+    params["_stretch_engine_float_body_bound"] = True
+    params["_stretch_engine_session"] = "sentinel-session"
+    config = _prepare_energy_config(image, params)
+    assert config["_stretch_engine_float_body_bound"] is True
+    assert config["_stretch_engine_session"] == "sentinel-session"
+    assert config["energy_float_backend"] == "matlab_engine"
+    assert "scales_per_octave" in config
+
+
+def test_exact_chunked_refuses_unbound_engine_numpy_body() -> None:
+    image = np.zeros((8, 8, 8), dtype=np.float64)
+    params = validate_parameters(
+        {
+            "energy_method": "hessian",
+            "energy_float_backend": "matlab_engine",
+            "comparison_exact_network": True,
+            "n_jobs": 6,
+            "max_voxels_per_node_energy": 1e9,
+        }
+    )
+    config = _prepare_energy_config(image, params)
+    with pytest.raises(MatlabEngineInfraError):
+        compute_exact_parity_energy_chunked(image, config)
+
+
+def test_resolve_python37_respects_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    missing = tmp_path / "no-python.exe"
+    monkeypatch.setenv(STRETCH_PY37_ENV, str(missing))
+    found = resolve_python37_executable()
+    if found is not None:
+        assert found.is_file()


### PR DESCRIPTION
## Summary
- Land stretch status/unlock taxonomy and hard crop→full gate without mutating Phase 1 ONE TRUTH CLOSED / ADR 0011–0012 ship bars.
- Add MATLAB-engine Energy adapter + `energy_float_backend=matlab_engine` / `matlab_engine_hessian` origin dispatch (no silent NumPy fallback under stretch stamp).
- Wire `--strict-floats` Energy unlock emission, discrete classification helpers, full-launch unlock refuse, and MKL-cannot-complete policy tests.

## U-IDs
- **Landed (foundation + gates):** U1, U2, U3, U4 (unit/gate wiring), U5 (classification helpers), U6 (full unlock gate), U7 (policy).
- **Not complete as stretch_complete:** Crop/full Energy bit-equal. Host repo Python is **3.12**; MATLAB R2019a Engine supports **≤3.7** → recorded as **`incomplete_infra`**, not allclose success.

## Test plan
- [x] `pytest` stretch unit suite (29 passed, 1 skipped engine happy-path)
- [x] `ruff check` on touched surfaces
- [ ] Operator: Python 3.7 + `matlab.engine` install → bind `energy_filter_V200` float body → crop `prove-exact --stage energy --strict-floats`
- [ ] Only then full stretch with matching unlock (never on `canonical_full_v18`)

## Post-Deploy Monitoring & Validation
No additional operational monitoring required — stretch is operator-host / CLI parity tooling; Phase 1 Certification path and defaults unchanged.

## Known Residuals
- Code review: skipped (`ce-code-review` / subagent dispatch unavailable this session); manual diff scan done.
- Engine float body not yet bound to `energy_filter_V200` through a live session; `ensure_matlab_engine_float_backend_ready` refuses NumPy under stretch stamp until bound.
- Leave open PRs #107/#109 alone.

## Plan
`docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md`

## Summary by Sourcery

Introduce a true zero-tolerance stretch parity program with MATLAB-engine backed Energy provenance, crop→full unlock gating, and stretch-specific status taxonomy that leaves Phase 1 Certification unchanged.

New Features:
- Add stretch-specific Energy provenance and float backend selection, including a MATLAB-engine Energy path usable by exact-route pipelines.
- Add CLI and proof helpers to emit stretch crop Energy unlock tokens on strict-float green proofs and gate full-volume stretch launches by matching unlocks and field sets.
- Introduce a stretch status taxonomy, unlock artifacts, and discrete strict-field helpers to track and expand stretch progress without altering ONE TRUTH Phase 1 results.

Enhancements:
- Extend parameter validation, energy config, and Watershed discovery predicates to understand energy_float_backend, stretch mode, and allow MATLAB-engine origins only under stretch.
- Update documentation and handoff notes to describe the true zero-tolerance stretch program, its unlock mechanics, and separation from Phase 1 Certification.

Tests:
- Add unit tests for stretch unlock and gate behavior, discrete strict-field classification, full-volume gating, stretch Energy provenance and backend enforcement, and MATLAB-engine adapter infra/policy behavior.