### PR TITLE
feat(parity): record crop Energy stretch as blocked_float_path

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,6 +1,6 @@
 # Phase 1 parity handoff and synthesis
 
-**Last synthesized:** 2026-08-14 (Phase 1 CLOSED on `canonical_full_v18`; ADR 0013 ranking fix verified)
+**Last synthesized:** 2026-08-16 (Phase 1 CLOSED unchanged; stretch operator notes: crop Energy `blocked_float_path`, do not relaunch v2)
 
 This is the operator brief for the current exact-route effort. Do not use
 dated agent passovers, PID snapshots, or parallel-work checklists as current
@@ -51,20 +51,16 @@ status. When findings [ONE TRUTH](../docs/reference/core/EXACT_PROOF_FINDINGS.md
 Labeled **stretch** — does **not** reopen Phase 1 CLOSED / ONE TRUTH.
 
 - Compare with `slavv parity prove-exact … --strict-floats` (default allclose ≠ stretch success).
-- Crop Energy unlock first (`crop_M_exact_v3` lineage / `180709_E_crop_M_v2`); full `180709_E` only after a matching unlock field set.
-- Engine float path: isolated Python 3.7 + `matlab.engine` (R2019a). Repo `.venv` is 3.12. Set `STRETCH_PY37_PYTHON`, then:
+- Crop Energy dest `crop_M_stretch_engine_v2` already finished; `--strict-floats` **FAIL**. Status **`blocked_float_path`**. **Do not relaunch** `resume-exact-run` / `--force-rerun-from energy` on that dest.
+- Inspect the existing proof only:
   ```powershell
-  slavv parity resume-exact-run `
-    --dest-run-root workspace\runs\oracle_180709_E\crop_M_stretch_engine_v2 `
-    --oracle-root workspace\oracles\180709_E_crop_M_v2 `
-    --dataset-root workspace\datasets\0cdf88e930482e9eb818963da22846c43b53b531582bf3aed83678b549863d06 `
-    --force-rerun-from energy --stop-after energy --n-jobs 1 `
-    --energy-float-backend matlab_engine
-  slavv parity prove-exact --stage energy --strict-floats ...
+  slavv parity inspect-proof --path workspace\runs\oracle_180709_E\crop_M_stretch_engine_v2\03_Analysis\exact_proof_energy.json
   ```
-- Never overwrite `canonical_full_v18`; use a new stretch dest root.
+- Live status: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v2/stretch_status.json`. Stretch session paragraph in findings (not ONE TRUTH).
+- U5/U6 stay gated until an Energy unlock token exists. Never overwrite `canonical_full_v18` or `crop_M_exact_v3`.
+- Parked next isolation (not a writer): one production-sized crop chunk vs MATLAB’s matching chunk. Do not treat whole-crop `get_energy_V202` as a cheap probe.
 - Status helpers: `slavv_python.analytics.parity.proof.stretch` (`gate_full_stretch_entry`, unlock + taxonomy).
-- Plan: [docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md](../docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md).
+- Plans: [true zero-tolerance stretch](../docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md), [E11–E20 experiments](../docs/plans/2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md). Runbook: [crop-energy-stretch-float-isolation.md](../docs/solutions/parity/crop-energy-stretch-float-isolation.md).
 
 ### Primary loop KPI
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -50,7 +50,8 @@ Former residual was Edge Selection Ranking Residual ([ADR 0013](adr/0013-claimed
 - [ ] **Phase 1 → Phase 2 handoff** — only after Network ADR 0012 green; no early Fortran-unwind.
 - [ ] **Paper-profile certification** — phase-1-spec F2 / R7 (volume + oracle TBD).
 - [ ] **neurovasc-db** — additional volumes after Phase 1 closed.
-- [ ] **Strict-field stretch (optional)** — exact connections / order-sensitive fields on crop after ship gate.
+- [ ] **Stretch Energy `--strict-floats`** — crop dest remains `blocked_float_path` (findings stretch subsection). Optional follow-up: one production-sized chunk isolation. U5/U6 gated. Do not relaunch v2.
+- [ ] **Strict-field stretch (optional)** — exact connections / order-sensitive fields on crop after Energy unlock.
 
 ---
 

--- a/docs/plans/2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md
+++ b/docs/plans/2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md
@@ -1,0 +1,582 @@
+---
+title: Zero-Tolerance Stretch Experiments E11-E20 - Plan
+type: feat
+date: 2026-08-15
+topic: zero-tolerance-stretch-experiments
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Zero-Tolerance Stretch Experiments E11-E20 - Plan
+
+## Goal Capsule
+
+- **Objective:** Deliver a second ranked portfolio of exactly **10** testable experiments (**E11–E20**) that falsify remaining true zero-tolerance gaps on the way to **100% parity** — bit-equal / strict-equality of every compared MATLAB↔Python field, including Energy floats, under `prove-exact --strict-floats`.
+- **Product authority:** This plan owns the E11–E20 experiment portfolio only. It **extends** the E1–E10 portfolio and the stretch program; it does **not** rewrite them. Phase 1 Certification on claim root `canonical_full_v18` stays **CLOSED** and is not reopened.
+- **Open blockers:** Crop Energy `--strict-floats` is **`blocked_float_path`** on `crop_M_stretch_engine_v2` (v1 remains the filter-only baseline). U5 discrete crop and U6 full volume remain gated on Energy unlock.
+- **Execution profile:** code — cheap fixtures and operator procedures; **not** a writer sprint. Do not start long MATLAB writers from this plan. Do not overwrite `canonical_full_v18` or `crop_M_exact_v3`.
+- **Stop when:** Crop then full `--strict-floats` pass for Energy **and** discrete (`stretch_complete`), **or** the program is recorded as `blocked_float_path` / `incomplete_discrete` / `incomplete_infra` / `incomplete_at_full` without redefining success as ADR 0011 allclose or ADR 0012 ownership-map green.
+
+---
+
+## Product Contract
+
+### Summary
+
+A durable second series of ten falsifiable experiments aimed at remaining **true zero-tolerance** gaps after Phase 1 CLOSED and after E1–E10 (ranking residual + audit honesty). Each experiment carries a hypothesis, cheap-first procedure, pass/fail criterion, artifacts, an explicit non-claim, and an estimated cost.
+
+**100% parity** here is the stretch bar already settled in `docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md`: every compared field bit-equal / strict equality, **including Energy floats**. Default `prove-exact` allclose is **not** stretch success and is **not** 100%. Evaluated ADR 0012 ownership-map / multiset green is **not** discrete stretch complete.
+
+Live stretch status lives in `stretch_status.json` beside stretch run roots, not in ONE TRUTH.
+
+### Problem Frame
+
+Phase 1 Certification is CLOSED on `canonical_full_v18`. E1–E10 closed the ranking-residual / audit-honesty loop (ADR 0013 claimed-trace bake; matlab2python audit = 0 genuine under production probes). The remaining “100%” gap is **stretch**: Energy floats are not bit-equal (v1 engine path ~62.5% voxels identical, ULP p50=1, status `blocked_float_path`), and discrete strict `connections` / emission order plus Vertices continuous floats are gated on Energy unlock. Without a second experiment series, operators will either reopen Phase 1, treat allclose or ADR 0012 ownership as 100%, or launch a full-volume writer before crop Energy unlocks.
+
+### Key Decisions
+
+- KD1. **100% means `--strict-floats` bit-equal / strict equality, including Energy floats.** (session-settled: user-directed — chosen over Phase-1 allclose-as-100% or ADR 0012 ownership-as-100%: default `prove-exact` allclose is not stretch success.) Governs R1, R2, R7.
+- KD2. **Phase 1 stays CLOSED.** (session-settled: user-directed — chosen over reopening ONE TRUTH / ADR 0011–0012 ship bars.) Governs R3.
+- KD3. **Extend E1–E10; do not duplicate or rewrite them.** (session-settled: user-directed — chosen over a replacement portfolio: new IDs are E11–E20.) Governs R4.
+- KD4. **Crop first; full `180709_E` only after a matching unlock field set.** (session-settled: user-directed — chosen over full-first: never overwrite `canonical_full_v18` or `crop_M_exact_v3`.) Governs R5, R9.
+- KD5. **If Energy never becomes bit-equal, status is `blocked_float_path` / incomplete — never allclose.** (session-settled: user-directed — chosen over softening the float bar.) Governs R2, R7.
+- KD6. **Discrete strict `connections` / order are in the same 100% bar, gated on Energy unlock.** (session-settled: user-directed — chosen over treating ADR 0012 ownership as discrete stretch.) Governs R8, R16.
+- KD7. **Cheap ladder + skip/block when artifacts missing; no writer sprint from this plan.** (session-settled: user-directed — chosen over launching crop/full writers to make the portfolio feel complete.) Governs R5, R6, R10.
+
+<!-- ce-section: work-relationships -->
+### How This Work Fits Together
+
+This plan owns the **E11–E20 zero-tolerance stretch experiments** only. Surrounding areas below are the current understanding, not a committed roadmap.
+
+- E1–E10 testable parity experiments (`docs/plans/2026-08-14-001-feat-testable-parity-experiments-plan.md`; shipped in `ca2e716d3`; not present on this `main` tip — **do not recreate**)
+  - **Predecessor** residual/audit portfolio; E11–E20 must not repeat those hypotheses
+  - **Can proceed independently of** this series (already defined)
+- True zero-tolerance stretch program (`docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md`, U1–U7)
+  - **Shares** `--strict-floats`, unlock tokens, status taxonomy
+  - This portfolio **prepares and falsifies** remaining U4–U7 gaps; it does not replace U4–U7 delivery
+- Phase 1 Certification (`canonical_full_v18`, ONE TRUTH CLOSED)
+  - **Outside** this plan’s identity; must remain CLOSED
+- Synthetic complexity ladder (PR #108) and double-junction harness (PR #109)
+  - **Outside** this plan; measurement bugs already fixed; tiny synthetics matched MATLAB
+- matlab2python `AUDIT_REPORT.md` (0 genuine under production probes)
+  - **Not** Certification and **not** stretch success
+
+### Actors
+
+- A1. Parity operator — runs cheap-first stretch experiments; records `stretch_status.json`; never promotes results into ONE TRUTH CLOSED language.
+- A2. Planning / implementation agent — adds only the tiny fixtures needed to make an experiment concrete; does not start long writers.
+- A3. MATLAB runtime (R2019a + isolated Python 3.7 `workspace/scratch/conda_py37_stretch`) — required for engine-path experiments; missing engine is `incomplete_infra` / skip, not fail-as-falsified.
+
+### Requirements
+
+**Portfolio rules**
+
+- R1. The portfolio contains exactly **10** new experiments **E11–E20**, each aimed at a remaining zero-tolerance gap (not E1–E10 duplicates).
+- R2. Stretch success for any float field is **`prove-exact --strict-floats` bit-identity** (or `np.array_equal` on a named fixture). Default allclose / ADR 0011 ship green is **not** 100% and **must not** emit a crop Energy unlock.
+- R3. No experiment may rewrite ONE TRUTH CLOSED language, ADR 0011/0012 ship bars, or claim-run roots.
+- R4. Every experiment records: hypothesis, cheap-first procedure, pass/fail, artifacts, what it does **not** prove, estimated cost, and a skip/block rule when artifacts are missing.
+- R5. Cost tiers follow the cheap ladder: `synthetic/unit` → `crop` → `full no-writer` → `full writer last`. Ranking, marshalling, and ULP-isolation hypotheses must not request a full writer.
+- R6. Missing artifacts, a live writer on the dest root, or a missing MATLAB engine → **skip/block**, not silent fail-as-falsified.
+
+**Hard bars (repeated because they are the 100% definition)**
+
+- R7. **Allclose is not 100%.** A crop or full Energy proof that passes default `prove-exact` and fails `--strict-floats` is `blocked_float_path` (or continue deepening), never stretch success.
+- R8. **ADR 0012 ownership-map green is not discrete stretch.** Exact `connections` / order-sensitive emission under the stretch discrete compare is required for the discrete field set. Ownership/multiset pass is Phase 1 Certification, already CLOSED.
+- R9. Full-volume stretch (Energy or discrete) runs only after a recorded crop unlock for the **same** field set. New dest roots only.
+- R10. This plan does not authorize starting `crop_M_stretch_engine_v2` (already running at write time), a third crop Energy writer, or any full `180709_E` stretch writer.
+
+**Experiments**
+
+- R11. **E11 — Crop Energy bit-equal after MATLAB `interp3` (v2 proof)**
+  - **Hypothesis:** After MATLAB owns FFT + `energy_filter_V200` + `interp3` + scale-min per chunk (`stretch_energy_chunk_v202` on dest `crop_M_stretch_engine_v2`), crop Energy is bit-identical to oracle `180709_E_crop_M_v2` under `--strict-floats`.
+  - **Cheap-first procedure:** Do **not** start a writer. If `stretch_status.json` is `crop_energy_running` or `writer_lease.json` PID is alive → **block**. When Energy stage completes, run `prove-exact --stage energy --strict-floats` against `180709_E_crop_M_v2` on that dest only. Unlock only on strict green.
+  - **Pass:** `energy_float_gate.passed=true` with `strict_floats=true`; 0 scale mismatches; Energy arrays bit-identical; Energy unlock token emitted.
+  - **Fail:** any non-identical Energy voxel → remain `blocked_float_path` (v1-style ULP is still failure). Allclose-only green is fail for this experiment.
+  - **Block:** writer still running; no `best_energy.npy` / energy checkpoint; proof JSON `dest_run_root` mismatch.
+  - **Artifacts:** `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v2/stretch_status.json`, `99_Metadata/writer_lease.json`, `02_Energy/`, `03_Analysis/exact_proof_energy.json` (after prove). Contrast v1 proof `crop_M_stretch_engine_v1/03_Analysis/exact_proof_energy.json`.
+  - **Does not prove:** Vertices/Edges/Network zero-tolerance; full-volume Energy; that ADR 0011 allclose is 100%; Phase 1 reopen.
+  - **Cost:** crop prove minutes after the already-running writer finishes (hours of compute already in flight — do not relaunch).
+
+- R12. **E12 — Engine transfer / `matlab.double` list-marshalling bit-identity**
+  - **Hypothesis:** The py37 worker path (`npy` → Fortran ravel → `[float(v) for v in flat]` → `matlab.double(..., size=)` → MATLAB → `_data` buffer → `np.save`) is bit-identical for float64 `[Y,X,Z]` arrays, so remaining crop ULP (if E11 fails) is **not** transfer.
+  - **Cheap-first procedure:** Unit fixture through the **production worker marshalling**, not only in-process `MatlabEngineSession.roundtrip_float64` (that helper skips on repo 3.12). Include Inf/NaN payloads. Skip if py37/engine absent (`incomplete_infra`).
+  - **Pass:** `np.array_equal` on finite values; Inf/NaN payload identity (NaN positions preserved).
+  - **Fail:** any finite ULP or shape/order change through the worker path.
+  - **Artifacts:** `scripts/stretch_matlab_engine_worker.py`; `slavv_python/pipeline/energy/matlab_engine_backend.py` (`numpy_to_matlab_double`); new test under `tests/unit/pipeline/energy/`.
+  - **Does not prove:** Energy math bit-equality vs oracle; crop unlock.
+  - **Cost:** `synthetic/unit` seconds; engine skip on CI.
+
+- R13. **E13 — Remaining ULP source isolation (linspace mesh, Inf/NaN `interp3`, chunk vs full body)**
+  - **Hypothesis:** If E11 fails after MATLAB `interp3`, the residual is one named source: (a) `linspace` coarse→fine mesh endpoints, (b) Inf/NaN `interp3` propagation, or (c) per-chunk `stretch_energy_chunk_v202` vs a single MATLAB `get_energy_V202` body on the same crop lattice.
+  - **Cheap-first procedure:** Tiny engine probes (one chunk / few scales) **before** another crop writer. Compare MATLAB-side `interp3` of a known Inf/NaN volume vs Python `_interp3_matlab_linear_inf`. Compare `linspace` meshes from `stretch_energy_chunk_v202` vs `get_energy_V202.m`. Isolate (c) only as a **small** engine call, not a full writer. Block if E11 still running.
+  - **Pass:** named source reproduces the v2 mismatch pattern (or all three sources bit-match, which **fails** this isolation hypothesis and forces a new named source — still `blocked_float_path`, not allclose success).
+  - **Fail:** isolation cannot attribute v2 mismatches to (a)(b)(c) and no new named source is recorded.
+  - **Artifacts:** `scripts/stretch_energy_chunk_v202.m`; `external/Vectorization-Public/source/get_energy_V202.m`; `slavv_python/pipeline/energy/matlab_get_energy_v202_chunked.py` (`_interp3_matlab_linear_inf`); v2 mismatch JSON if prove has run.
+  - **Does not prove:** crop Energy unlock; that deepening MATLAB surface is complete.
+  - **Cost:** `synthetic/unit` minutes on operator host with MATLAB; skip without engine.
+
+- R14. **E14 — Optional whole-crop MATLAB `get_energy_V202` engine call**
+  - **Hypothesis:** One in-process MATLAB `get_energy_V202` on the crop volume (Python still owns I/O and checkpoint packaging) is bit-equal to oracle Energy, isolating chunk-lattice / per-chunk marshalling from MATLAB’s own full-body Energy.
+  - **Cheap-first procedure:** Only after E12 is green (transfer not the confounder) and only if E11 failed or is inconclusive. Memory-check the crop `(64,256,256)` first. Skip if engine/oracle/volume missing. **Do not** treat MATLAB-written Energy with Python never producing Energy as stretch success (stretch plan R6).
+  - **Pass:** `--strict-floats` bit-equal vs `180709_E_crop_M_v2` Energy from a Python-orchestrated engine call.
+  - **Fail:** still not bit-equal → `blocked_float_path` with “even MATLAB `get_energy_V202` via engine ≠ oracle” (oracle/transfer/params), not allclose success.
+  - **Block:** E11 writer still running on another dest is fine; do not overwrite v2. New scratch dest only.
+  - **Artifacts:** new scratch dest under `workspace/scratch/` or a new stretch dest; never `canonical_full_v18` / `crop_M_exact_v3` / in-flight v2.
+  - **Does not prove:** production chunked path unlock; full-volume Energy; discrete stretch.
+  - **Cost:** `crop` minutes; optional; skip rather than OOM.
+
+- R15. **E15 — Vertices `lumen_radius` / continuous floats under `--strict-floats`**
+  - **Hypothesis:** After Energy unlock, Vertices discrete positions/scales already match, but continuous fields (`energies`, and Energy-stage `lumen_radius_microns` in `EXACT_STAGE_FIELDS`) still fail `--strict-floats`.
+  - **Cheap-first procedure:** **Gated on Energy unlock.** Unit fixture first (strict vs allclose on a Vertices float vector). Then crop `prove-exact --stage vertices --strict-floats` on a **new** stretch dest that carries unlocked Energy. Do not run Vertices writer until Energy unlock exists. Skip if unlock missing.
+  - **Pass:** all compared Vertices fields bit-equal / strict under `--strict-floats`.
+  - **Fail:** any continuous Vertices/Energy-radius field not bit-equal → record as incomplete Vertices-float stretch (still under stretch R1; stretch plan ASSUME5), **not** Phase 1 fail.
+  - **Artifacts:** `slavv_python/analytics/parity/proof/exact_proof_contract.py`; crop vertices checkpoint; unlock token.
+  - **Does not prove:** Edges/Network discrete stretch; full volume; Phase 1 Vertices allclose ship (already CLOSED).
+  - **Cost:** unit seconds; crop minutes after unlock.
+
+- R16. **E16 — Discrete strict `connections` / emission order on crop after Energy unlock**
+  - **Hypothesis:** With bit-equal crop Energy, crop Edges/Network still fail exact `connections` / order-sensitive emission (`incomplete_discrete`). ADR 0012 ownership-map green on Phase 1 does **not** satisfy this.
+  - **Cheap-first procedure:** **Gated on Energy unlock.** Reuse stretch helpers `evaluate_stretch_discrete_connections` / `expand_unlock_with_discrete`. Crop no-writer re-selection first if candidates exist on the stretch dest; crop Edges writer only if cheap layer cannot speak. Compare strict `connections` (and documented order-sensitive emission), not ownership %.
+  - **Pass:** exact connections match → expand unlock to `energy+discrete`.
+  - **Fail:** mismatch → `incomplete_discrete` (not `blocked_float_path`, not Phase 1 red).
+  - **Block:** no Energy unlock; missing crop candidates/oracle.
+  - **Artifacts:** `tests/unit/parity/test_stretch_discrete_strict_field.py`; crop oracle `180709_E_crop_M_v2`; stretch dest Edges checkpoints (new root).
+  - **Does not prove:** Phase 1 ADR 0012; full-volume discrete; that ranking/cleanup is the residual (see E17).
+  - **Cost:** unit seconds already covered; crop minutes after unlock; writer last.
+
+- R17. **E17 — Claimed-trace ranking + cleanup MATLAB comparator (regression, not Phase 1)**
+  - **Hypothesis:** ADR 0013 claimed-trace bake and crop cleanup MATLAB comparator remain green on existing crop artifacts. This is a **regression guard** so operators do not reopen ranking as the 100% gap.
+  - **Cheap-first procedure:** No-writer crop probes already in HANDOFF (`watershed_frontier_diff.py`, `compare_clean_edge_pairs_matlab.py`, E1–E4 surfaces). Do **not** launch an Edges writer. Do **not** cite this as Phase 1 work.
+  - **Pass:** crop raw pair-set / cleanup comparator still agree; claimed-map ranking still prefers the documented oracle partner on stored fixtures.
+  - **Fail:** ranking/cleanup regression → fix as stretch-adjacent production regression, still without reopening ONE TRUTH CLOSED.
+  - **Artifacts:** `crop_M_exact_v3` candidates (read-only); `scripts/compare_clean_edge_pairs_matlab.py`; `tests/unit/pipeline/test_watershed_energy_map_sort_experiments.py`.
+  - **Does not prove:** Energy bit-equality; discrete stretch complete; Phase 1 anything new.
+  - **Cost:** `crop` / `full no-writer` minutes; never a writer for this ID.
+
+- R18. **E18 — MKL / in-process NumPy spike as falsifier only (U7)**
+  - **Hypothesis:** In-process MKL/NumPy Energy is **not** bit-equal on crop (v1 already showed ~62.5% even with MATLAB filter + Python `interp3`). Even a hypothetical MKL bit-equal crop **must not** replace the engine path or emit `stretch_complete`.
+  - **Cheap-first procedure:** Cite v1 `--strict-floats` fail as the existing NumPy/engine-hybrid falsifier. Optional short MKL-thread spike only if someone claims “MKL alone would unlock.” Policy test already in `tests/unit/parity/test_mkl_spike_does_not_replace_engine.py`. Do not start an MKL crop writer from this plan.
+  - **Pass:** policy helper rejects “MKL pass ⇒ stretch complete”; NumPy-only / hybrid path remains `--strict-floats` red (or spike documented as falsifier-only).
+  - **Fail:** someone records stretch unlock from an MKL/NumPy dest without engine origin stamp.
+  - **Artifacts:** v1 `stretch_status.json` (`blocked_float_path`); `mkl_spike_cannot_complete_stretch`.
+  - **Does not prove:** engine path will unlock; full volume.
+  - **Cost:** `synthetic/unit`; optional spike minutes; never replaces E11.
+
+- R19. **E19 — Full-volume stretch unlock gate + `(512,64,512)` orientation pitfall**
+  - **Hypothesis:** Full stretch prove/launch without a matching crop unlock is refused; a full Energy array shaped `(512,64,512)` is an orientation defect (`incomplete_infra` / refuse), not a float-bar near-miss, and never overwrites `canonical_full_v18`.
+  - **Cheap-first procedure:** Unit tests already in `tests/unit/parity/test_stretch_full_volume_gate.py`. Add a fixture that a `(512,64,512)` Energy checkpoint fails stretch prove **before** ULP accounting. Do **not** start a full writer. After Energy unlock, full Energy-only may be authorized later by stretch U6 — **not** by this experiment’s DoD.
+  - **Pass:** no-unlock → `FULL_REFUSED`; claim-root dest refused; orientation mismatch classified as infra/refuse, not allclose pass.
+  - **Fail:** full stretch proceeds without unlock, or orientation mismatch is reported as `blocked_float_path`.
+  - **Artifacts:** `slavv_python/analytics/parity/proof/stretch.py` (`gate_full_stretch_entry`); `docs/solutions/parity/resume-energy-orientation.md`.
+  - **Does not prove:** full Energy bit-equality; `stretch_complete`.
+  - **Cost:** `synthetic/unit` seconds.
+
+- R20. **E20 — High-octave crop≠full Energy lesson before any full stretch writer**
+  - **Hypothesis:** Crop Energy bit-equal (E11) does **not** imply full-volume Energy bit-equal at downsampled octaves where the crop is 1 chunk and full `180709_E` is many chunks (historical octave-4 `rf=[5,10,10]` lesson). A cheap high-octave chunk-vs-full engine probe must pass (or name the residual) **before** a full stretch writer.
+  - **Cheap-first procedure:** **Gated on Energy unlock.** Unit/synthetic: same downsampled octave, 1 chunk vs N chunks, engine `stretch_energy_chunk_v202`, `np.array_equal` on overlap interiors. Skip if unlock missing. Full `180709_E` writer is **last** and only with Energy-only unlock + this probe green (or an explicit `incomplete_at_full` risk acceptance recorded in `stretch_status.json`, never as allclose success).
+  - **Pass:** multi-chunk vs single-chunk engine Energy bit-identical on the fixture.
+  - **Fail:** divergence → do not launch full stretch writer; status stays crop-unlocked / `incomplete_at_full` risk, not 100%.
+  - **Artifacts:** `docs/solutions/parity/canonical-energy-high-octave-divergence.md`; engine chunk helper; new unit under `tests/unit/pipeline/energy/`.
+  - **Does not prove:** full `--strict-floats` vs `180709_E_full_v2`; discrete stretch; Phase 1 Energy allclose (already CLOSED).
+  - **Cost:** `synthetic/unit` minutes with engine; full writer last and out of this plan’s launch authority.
+
+### Key Flows
+
+- F1. Energy-unlock ladder (E12 → E11 → E13/E14 if red → E18 as falsifier)
+  - **Trigger:** Operator wants crop Energy `--strict-floats` unlock.
+  - **Actors:** A1, A2, A3
+  - **Steps:** Run E12 if engine available (does not need v2). Wait for v2 writer; never start a second. Prove E11. If red, isolate with E13 then optional E14. E18 cannot unlock.
+  - **Outcome:** Energy unlock **or** durable `blocked_float_path`.
+  - **Covered by:** R11, R12, R13, R14, R18, R7, R10
+
+- F2. Post-unlock discrete / Vertices ladder (E15, E16, E17)
+  - **Trigger:** Energy unlock token present for crop dest/oracle pairing.
+  - **Actors:** A1, A2
+  - **Steps:** E17 regression first (cheap, no writer). E15 Vertices floats. E16 strict connections. Failures are `incomplete_discrete` / Vertices-float incomplete, not Phase 1.
+  - **Outcome:** `energy+discrete` unlock or `incomplete_discrete`.
+  - **Covered by:** R15, R16, R17, R8
+
+- F3. Full-volume refuse-then-prepare (E19, E20)
+  - **Trigger:** Operator considers full `180709_E` stretch.
+  - **Actors:** A1, A2
+  - **Steps:** E19 gate must refuse without matching unlock and refuse claim-root overwrite. E20 high-octave probe before any full writer. This plan does not launch that writer.
+  - **Outcome:** full entry allowed only with matching unlock + orientation/high-octave checks; else refuse / `incomplete_at_full`.
+  - **Covered by:** R9, R19, R20
+
+### Acceptance Examples
+
+- AE1. Allclose is not 100%
+  - **Covers:** R2, R7, R11
+  - **Given:** Crop Energy proof with default allclose green and `--strict-floats` red (v1: ~62.5% bit-identical)
+  - **When:** Operator asks if stretch / 100% is done
+  - **Then:** Status remains `blocked_float_path`; no Energy unlock; ONE TRUTH still CLOSED
+
+- AE2. ADR 0012 ownership is not discrete stretch
+  - **Covers:** R8, R16
+  - **Given:** Phase 1 Edges ownership ~99.999863% PASS on `canonical_full_v18`
+  - **When:** Discrete stretch is scored
+  - **Then:** Ownership green does not expand unlock to `energy+discrete`; exact `connections` / order still required
+
+- AE3. V2 writer still running is block, not fail
+  - **Covers:** R6, R11, R10
+  - **Given:** `crop_M_stretch_engine_v2` lease PID alive and `stretch_status.json` is `crop_energy_running`
+  - **When:** E11 is attempted
+  - **Then:** Experiment is **blocked**; no second writer; no false-falsify of the interp3 hypothesis
+
+- AE4. Full without unlock refused
+  - **Covers:** R9, R19
+  - **Given:** No crop Energy unlock token
+  - **When:** Full stretch prove/launch is requested
+  - **Then:** `FULL_REFUSED`; `canonical_full_v18` not used as dest
+
+### Success Criteria
+
+- E11–E20 each have a named cheap-first procedure, pass/fail, skip/block rule, and non-claim.
+- Crop Energy `--strict-floats` either unlocks (E11 green) or is explicitly `blocked_float_path` after E13/E14 (never allclose).
+- Discrete stretch is scored only after Energy unlock and only via exact connections/order (E16), not ADR 0012.
+- Full stretch is not launched from this plan; E19/E20 only prepare/refuse.
+- Phase 1 ONE TRUTH remains CLOSED on `canonical_full_v18`.
+
+### Scope Boundaries
+
+**In scope**
+
+- E11–E20 definitions, composition, stop conditions
+- Tiny fixtures that make E12/E13/E19/E20 concrete
+- Operator procedures that wait on / prove existing v2 dest
+
+**Deferred for later**
+
+- Stretch U5/U6 **delivery** (crop discrete writer, full stretch writer) after unlock — this portfolio may *prepare* them
+- Additional volumes beyond `180709_E` / crop_M
+- Packaging MATLAB Engine for all users
+
+**Outside this product's identity**
+
+- Reopening Phase 1 or changing ADR 0011/0012 ship bars
+- Rewriting E1–E10, the synthetic ladder, or AUDIT_REPORT as Certification
+- Starting long crop/full writers from this plan
+- Treating MKL spike (E18) as the engine replacement
+- Static transpilers (`matlab2python`) as stretch verification
+
+### Dependencies / Assumptions
+
+- Stretch plan U1–U4 surfaces already exist (`stretch.py`, engine host, `--strict-floats` unlock helpers).
+- Isolated Python 3.7 + R2019a engine at `workspace/scratch/conda_py37_stretch` for operator-host engine tests; repo `.venv` is 3.12.
+- Crop oracle `180709_E_crop_M_v2` and full oracle `180709_E_full_v2` remain the compare surfaces.
+- Live v2 Energy writer (observed at plan write) is allowed to finish; this plan must not kill or duplicate it.
+- E1–E10 plan file may be absent on this `main` tip; series identity still holds — do not recreate E1–E10 in this file.
+
+### Outstanding Questions
+
+**Resolve Before Planning**
+
+- None. Session-settled bars and crop-first / no-writer-sprint constraints are sufficient.
+
+**Deferred to Implementation**
+
+- Exact E14 MATLAB entry (`get_energy_V202` vs a thin wrapper) if E11 fails and memory allows.
+- Whether E15 compares Energy-stage `lumen_radius_microns` only or also Vertices `energies` in the same prove invocation (both are in `EXACT_STAGE_FIELDS`; implementer must name the field list in the fixture).
+
+---
+
+## Planning Contract
+
+### Assumptions
+
+- ASSUME1. **Do not assume v2 Energy unlock.** At plan write, `crop_M_stretch_engine_v2` was `crop_energy_running` (~301/821 chunks, lease PID 4448 alive). E11 blocks until that dest’s Energy stage completes and `--strict-floats` is run.
+- ASSUME2. **Energy-first unlock still holds** (stretch plan ASSUME1). E15–E16–E20 must not run as if discrete/full were unlocked.
+- ASSUME3. **Existing gate unit tests count** for E16/E18/E19 policy; this portfolio adds missing **production-path** fixtures (py37 worker marshalling, Inf/NaN interp3, orientation-before-ULP, high-octave chunk-vs-full).
+- ASSUME4. **CI skips engine tests** when MATLAB/py37 is absent; skip ≠ fail.
+- ASSUME5. **v1 remains the blocked baseline** (`blocked_float_path`, 2,623,250 / 4,194,304 bit-identical, 0 scale mismatches, max abs delta `1e-10`, ULP p50=1). Do not delete or overwrite v1.
+
+### Key Technical Decisions
+
+- KTD1. **E11 dest is `crop_M_stretch_engine_v2` only; prove, don’t relaunch.** Instantiates R11, R10, AE3.
+- KTD2. **E12 targets the py37 worker list-marshalling path**, not only `MatlabEngineSession.roundtrip_float64` (skipped on 3.12). Instantiates R12.
+- KTD3. **E13/E14 run only if E11 is red or blocked-after-complete**, except E12 which is independent and cheap. Instantiates F1.
+- KTD4. **Reuse stretch status taxonomy** (`blocked_float_path`, `incomplete_discrete`, `incomplete_infra`, `incomplete_at_full`, `FULL_REFUSED`). Do not invent a fifth “allclose-complete” state. Instantiates R7, R8.
+- KTD5. **New stretch dest roots only** for any later writer authorized *after* this portfolio. Instantiates R3, R9.
+- KTD6. **No portfolio CLI.** Map E11–E20 to pytest nodes / existing `slavv parity prove-exact` / documented probes, same as E1–E10 KTD1.
+
+### High-Level Technical Design
+
+#### Composition / stop conditions
+
+```mermaid
+flowchart TD
+  E12[E12 transfer roundtrip]
+  E11[E11 v2 crop Energy --strict-floats]
+  E13[E13 ULP isolation]
+  E14[E14 optional whole-crop get_energy_V202]
+  E18[E18 MKL falsifier only]
+  UL[Energy unlock token]
+  BF[blocked_float_path]
+  E17[E17 ADR 0013 / cleanup regression]
+  E15[E15 Vertices floats]
+  E16[E16 strict connections]
+  ID[incomplete_discrete]
+  ED[energy+discrete unlock]
+  E19[E19 full gate + orientation]
+  E20[E20 high-octave chunk vs full]
+  FULL[full writer LAST - not launched by this plan]
+
+  E12 --> E11
+  E18 -.->|cannot unlock| E11
+  E11 -->|strict green| UL
+  E11 -->|strict red| E13
+  E13 --> E14
+  E14 -->|still red| BF
+  E14 -->|green but not production path| E13
+  UL --> E17
+  UL --> E15
+  UL --> E16
+  E16 -->|mismatch| ID
+  E16 -->|exact connections| ED
+  UL --> E19
+  UL --> E20
+  E19 -->|no unlock| E19
+  E20 -->|probe green + unlock| FULL
+```
+
+Stop:
+
+1. E11 red after E13/E14 exhausted → **`blocked_float_path`**. Never allclose. Do not start U5/U6/full.
+2. E11 green, E16 red → **`incomplete_discrete`**. Energy-only full may be considered later by stretch U6; this plan still does not launch it.
+3. Unlock missing → E15/E16/E20 **block**; E19 refuses full.
+4. `stretch_complete` is **out of this plan’s launch authority**; this portfolio only prepares the falsifiers that would justify a later U6 run.
+
+#### Live v2 observation (plan write, 2026-08-15 evening CT)
+
+Recorded so implementers do not treat unlock as already true. Re-read disk; do not freeze these as ONE TRUTH KPIs.
+
+- `crop_M_stretch_engine_v1`: `blocked_float_path`; `--strict-floats` FAIL; 62.5% voxels bit-identical; 0 scale mismatches; cause was Python `interp3` after MATLAB `energy_filter_V200`.
+- `crop_M_stretch_engine_v2`: `stretch_status.json` status `crop_energy_running`; `float_body=stretch_energy_chunk_v202`; lease PID **4448** (`python`, started 2026-08-16T01:57:50Z); Energy **301/821** chunks; heartbeat `2026-08-16T03:10:22Z`; no `03_Analysis` proof yet; `02_Energy` has `resume_state.json` only (no `best_energy.npy` yet).
+- Snapshot `artifacts.energy.*` still pointed at **v1** npy paths — do not cite those as v2 results.
+
+### Alternative Approaches Considered
+
+| Approach | Why not |
+|:---------|:--------|
+| Rewrite E1–E10 with stretch IDs | User directed extend-not-duplicate; ranking/audit hypotheses are closed |
+| Launch a new crop/full Energy writer to “have results in the plan” | Violates KD7 / R10; v2 already running |
+| Score 100% from ADR 0012 ownership or allclose | Violates KD1 / R7 / R8 |
+| MKL-first instead of engine v2 prove | Stretch KTD8 / E18: falsifier only |
+
+### Risks & Dependencies
+
+| Risk | Mitigation |
+|:-----|:-----------|
+| False-falsify E11 while v2 is mid-write | AE3 block on live lease / missing checkpoint |
+| Cite v1 npy via v2 snapshot artifact aliases | Pair proof `dest_run_root` to the folder opened; inspect-proof |
+| E14 MATLAB-only Energy treated as Python stretch success | Stretch R6 / `refuse_matlab_only_energy_checkpoint_as_stretch_success` |
+| Full orientation `(512,64,512)` misread as ULP | E19 classifies as infra/refuse first |
+| High-octave crop green ≠ full | E20 before any full writer |
+| Engine missing on CI | skip/`incomplete_infra`, not fail |
+
+### System-Wide Impact
+
+- No change to default `prove-exact` allclose (ADR 0011).
+- No ONE TRUTH CLOSED edits.
+- Stretch dest roots and `stretch_status.json` only.
+- Writer lease: do not take a second lease on `crop_M_stretch_engine_v2`.
+
+---
+
+## Implementation Units
+
+### U1. E11 v2 crop Energy prove procedure (no new writer)
+
+- **Goal:** Make E11 runnable as wait → prove → unlock-or-block, without launching Energy.
+- **Requirements:** R11, R6, R7, R10; AE1, AE3; KTD1
+- **Dependencies:** None
+- **Files:**
+  - Read-only: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v2/`
+  - Modify (docs only if a one-liner operator map is needed): `docs/solutions/best-practices/parity-experiment-hygiene.md` — prefer a short E11–E20 ladder subsection, not a new hygiene rewrite
+  - Test: extend `tests/unit/parity/test_stretch_crop_energy_strict_floats.py` only if a “running dest / missing energy checkpoint → no unlock” case is absent
+- **Approach:**
+  1. Document the block predicate: live `writer_lease.json` PID **or** Energy stage not `completed` **or** missing energy checkpoint → E11 blocked.
+  2. When complete: `slavv parity prove-exact --stage energy --strict-floats` with dest `crop_M_stretch_engine_v2` and oracle `180709_E_crop_M_v2`.
+  3. Unlock only via existing `emit_stretch_energy_unlock_if_eligible` (allclose without strict must not unlock — already tested).
+- **Test scenarios:**
+  - Covers AE3. Missing checkpoint / non-strict report → no unlock.
+  - Covers AE1. Allclose-green + strict-red → no unlock.
+- **Verification:** No new writer started; v2 lease left untouched.
+
+### U2. E12 worker marshalling + E13 ULP isolation fixtures
+
+- **Goal:** Cheap falsifiers for transfer vs linspace vs Inf/NaN `interp3` vs chunk-vs-full body.
+- **Requirements:** R12, R13; KTD2, KTD3
+- **Dependencies:** None (parallel with U1)
+- **Files:**
+  - Create: `tests/unit/pipeline/energy/test_stretch_worker_marshalling.py` (skip without py37/engine)
+  - Create: `tests/unit/pipeline/energy/test_stretch_ulp_isolation.py` (Inf/NaN interp3 + linspace mesh; engine cases skip)
+  - Read: `scripts/stretch_matlab_engine_worker.py`, `matlab_engine_backend.py`, `_interp3_matlab_linear_inf`
+- **Approach:**
+  1. E12: round-trip a Fortran `[Y,X,Z]` float64 array through the **same** `float` list + `matlab.double(size=)` + `_data` reshape the worker uses; include Inf/NaN.
+  2. E13: fixture MATLAB-compatible Inf propagation vs `_interp3_matlab_linear_inf`; fixture `linspace` endpoint equality vs `stretch_energy_chunk_v202` mesh. Do not start a crop writer.
+- **Test scenarios:**
+  - Happy path: finite random array `np.array_equal` after worker-shaped marshalling (skip if no engine).
+  - Inf/NaN positions preserved.
+  - Linspace mesh endpoints match the `.m` formula for a tiny `rf`/`offset`/`count`.
+- **Verification:** CI green with skips; operator-host engine run optional.
+
+### U3. E14 optional whole-crop `get_energy_V202` (skip-first)
+
+- **Goal:** Define the optional isolation call so it cannot be mistaken for production unlock or MATLAB-only success.
+- **Requirements:** R14; stretch plan R6
+- **Dependencies:** U2 (E12 green preferred)
+- **Files:**
+  - Create: short operator note in this plan’s Appendix map is enough unless a thin script is required — if a script is added, `scripts/stretch_whole_crop_get_energy_v202.py` under 1000 lines, skip-if-missing, write only under `workspace/scratch/`
+  - Test: `tests/unit/pipeline/energy/test_stretch_whole_crop_get_energy_policy.py` — refuses MATLAB-only checkpoint as stretch success; refuses overwrite of v2/claim roots
+- **Approach:** Policy + skip path first. Implement the engine call only if E11 completes red and E12 is green.
+- **Test scenarios:**
+  - Dest in `{canonical_full_v18, crop_M_exact_v3, crop_M_stretch_engine_v2}` refused.
+  - `refuse_matlab_only_energy_checkpoint_as_stretch_success` still raises.
+- **Verification:** No crop writer; scratch-only if executed later.
+
+### U4. E15 Vertices floats + E16 discrete connections (gated)
+
+- **Goal:** After Energy unlock, score Vertices continuous fields and exact connections without treating ADR 0012 as pass.
+- **Requirements:** R15, R16, R8; AE2
+- **Dependencies:** U1 (Energy unlock)
+- **Files:**
+  - Extend: `tests/unit/parity/test_stretch_discrete_strict_field.py` (already covers ownership ≠ exact connections)
+  - Create: `tests/unit/parity/test_stretch_vertices_strict_floats.py` — fixture allclose-green / strict-red on a Vertices `energies` vector does not expand discrete unlock
+- **Approach:** Gate functions must no-op / block without Energy unlock. Do not start Vertices/Edges writers in this unit.
+- **Test scenarios:**
+  - Covers AE2. Exact connections required to expand unlock.
+  - No Energy unlock → E15/E16 helpers refuse.
+  - Vertices float mismatch → not `blocked_float_path`.
+- **Verification:** Unit tests; crop prove listed as operator step after unlock, not this unit’s launch.
+
+### U5. E17 ranking/cleanup regression (read-only)
+
+- **Goal:** Keep ADR 0013 / cleanup comparator as a cheap regression, explicitly not Phase 1 and not 100%.
+- **Requirements:** R17
+- **Dependencies:** None
+- **Files:**
+  - Reuse: `tests/unit/pipeline/test_watershed_energy_map_sort_experiments.py`
+  - Reuse: `scripts/compare_clean_edge_pairs_matlab.py`
+  - Do not modify production ranking
+- **Approach:** Document E17 entrypoints in the Appendix map. Skip if crop candidates missing.
+- **Test scenarios:** Existing E1/E2 unit coverage remains green; E17 non-claim language in the operator map.
+- **Verification:** No writer; no ONE TRUTH edit.
+
+### U6. E18 MKL falsifier policy (already present)
+
+- **Goal:** Keep MKL/NumPy from replacing Approach A.
+- **Requirements:** R18
+- **Dependencies:** None
+- **Files:**
+  - Reuse: `tests/unit/parity/test_mkl_spike_does_not_replace_engine.py`
+- **Approach:** Cite v1 `--strict-floats` fail as the empirical falsifier. No new MKL writer.
+- **Test scenarios:** `mkl_bit_equal=True` still cannot complete stretch.
+- **Verification:** Policy test green.
+
+### U7. E19 full gate/orientation + E20 high-octave probe fixture
+
+- **Goal:** Refuse full stretch without unlock; catch `(512,64,512)` before ULP; require high-octave chunk-vs-full bit-identity before any later full writer.
+- **Requirements:** R19, R20, R9; AE4
+- **Dependencies:** E20 engine fixture may skip; E19 units do not need unlock
+- **Files:**
+  - Extend: `tests/unit/parity/test_stretch_full_volume_gate.py` — orientation shape `(512,64,512)` vs oracle `(64,512,512)` is refuse/infra
+  - Create: `tests/unit/pipeline/energy/test_stretch_high_octave_chunk_vs_full.py` — 1-chunk vs N-chunk merge identity on a tiny downsampled lattice (engine skip; numpy merge identity still testable)
+- **Approach:** Do not launch full `180709_E`. E20 production engine compare is operator-host after Energy unlock.
+- **Test scenarios:**
+  - Covers AE4. Missing unlock → `FULL_REFUSED`.
+  - Claim dest name `canonical_full_v18` refused.
+  - Shape `(512,64,512)` fails before float gate.
+  - Tiny min-merge of two chunks equals single-window result on overlap (numpy stand-in when engine absent).
+- **Verification:** Unit tests; no full writer.
+
+---
+
+## Verification Contract
+
+| Gate | Command / surface | Counts as 100%? |
+|:-----|:------------------|:----------------|
+| Default unit CI | `python -m pytest tests/unit/parity/test_stretch_*.py tests/unit/pipeline/energy/test_stretch_*.py tests/unit/pipeline/energy/test_matlab_engine_backend.py` | No |
+| Engine tests | same files; skip without MATLAB/py37 | Skip ≠ fail |
+| E11 crop Energy | `slavv parity prove-exact --stage energy --strict-floats` on `crop_M_stretch_engine_v2` vs `180709_E_crop_M_v2` **after** writer complete | Energy unlock only if strict green |
+| Default `prove-exact` (no `--strict-floats`) | existing ADR 0011 allclose | **Never** stretch / 100% |
+| Evaluated ADR 0012 | `canonical_full_v18` Edges/Network | Phase 1 CLOSED only; **not** discrete stretch |
+| Quality | `ruff` / `mypy` on touched tests; 1000-line file limit; no inline imports; float64; `[Y,X,Z]` Fortran | — |
+
+---
+
+## Definition of Done
+
+**Global**
+
+- [ ] E11–E20 each have hypothesis, cheap-first procedure, pass/fail, artifacts, non-claim, cost, skip/block.
+- [ ] Composition and stop conditions are explicit: allclose ≠ 100%; ADR 0012 ownership ≠ discrete stretch.
+- [ ] Tiny fixtures for E12/E13/E19/E20 (and policy for E14/E16/E18) exist or reuse existing tests.
+- [ ] No long crop/full writer started from this plan; `canonical_full_v18` and `crop_M_exact_v3` not overwritten.
+- [ ] ONE TRUTH Phase 1 CLOSED language untouched.
+- [ ] Abandoned spike scripts stay out of `slavv_python/` (scratch only).
+
+**Per unit**
+
+- U1: E11 block/prove procedure documented; no second v2 writer.
+- U2: marshalling + ULP isolation tests skip-clean.
+- U3: E14 cannot overwrite protected roots or count MATLAB-only Energy as success.
+- U4: Vertices-float + discrete tests gated; ownership ≠ exact connections.
+- U5: E17 maps to existing no-writer probes.
+- U6: MKL policy test still green.
+- U7: full refuse + orientation + high-octave fixture tests green.
+
+---
+
+## Appendix
+
+### Experiment → harness map
+
+| ID | Cost | Primary harness | Unlock role |
+|----|------|-----------------|-------------|
+| E11 | crop prove (after in-flight writer) | `prove-exact --stage energy --strict-floats` on `crop_M_stretch_engine_v2` | **Energy unlock** or `blocked_float_path` |
+| E12 | unit | `tests/unit/pipeline/energy/test_stretch_worker_marshalling.py` | Independent; cannot unlock |
+| E13 | unit | `tests/unit/pipeline/energy/test_stretch_ulp_isolation.py` | Only if E11 red |
+| E14 | crop optional | scratch whole-crop `get_energy_V202` engine call | Isolation only; not production unlock |
+| E15 | unit then crop | `test_stretch_vertices_strict_floats.py` then vertices `--strict-floats` | After Energy unlock |
+| E16 | unit then crop | `test_stretch_discrete_strict_field.py` then stretch discrete compare | Expands to `energy+discrete` |
+| E17 | crop no-writer | existing E1–E4 / `compare_clean_edge_pairs_matlab.py` | Regression; not 100% |
+| E18 | unit | `test_mkl_spike_does_not_replace_engine.py` + v1 status | Cannot unlock |
+| E19 | unit | `test_stretch_full_volume_gate.py` | Refuse full without unlock |
+| E20 | unit then engine | `test_stretch_high_octave_chunk_vs_full.py` | Required before later full writer |
+
+### Must-read before running experiments
+
+1. `docs/plans/2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md`
+2. `docs/reference/core/EXACT_PROOF_FINDINGS.md` (ONE TRUTH CLOSED + stretch subsection)
+3. `.claude/HANDOFF.md` (stretch operator notes)
+4. `docs/solutions/best-practices/parity-experiment-hygiene.md`
+5. `docs/solutions/parity/canonical-energy-high-octave-divergence.md`
+6. `docs/solutions/parity/resume-energy-orientation.md`
+7. `docs/solutions/parity/crop-energy-stretch-float-isolation.md`
+
+### Predecessor portfolio (do not duplicate)
+
+E1 claimed-map ranking; E2 degree-excess earlier-row; E3 crop raw pair-set; E4 full no-writer re-selection; E5 MATLAB-edge Network isolation; E6 ProductionProbe honesty; E7 13/13 coverage; E8 static ≠ GENUINE; E9 ParityModuleMap seam; E10 cheap-loop gate.
+Those IDs remain the first series. This file is **E11–E20** only.
+
+### Outcomes (2026-08-16 wrap)
+
+Stop condition met: crop Energy recorded **`blocked_float_path`**. Allclose is not stretch success. Phase 1 CLOSED unchanged. Do not relaunch v2.
+
+| ID | Result | Notes |
+|----|--------|-------|
+| E11 | **FAIL** | v2 `--strict-floats`: 3,786,847 / 4,194,304 bit-identical (90.3%); 407,457 mismatches; 0 scale mismatches. No Energy unlock. |
+| E12 | **PASS** | py37 `matlab.double` marshalling bit-identical (finite + Inf/NaN/`-0.0`). Transfer is not the residual. |
+| E13 | **FAIL** (isolation hypothesis) | Linspace, Inf `interp3`, tiny chunk-vs-full bit-matched. Did not name the v2 ULP source. |
+| E14 | **deferred** (`incomplete_infra`) | Whole-crop MATLAB `get_energy_V202` is octave-chunked (726 chunks on octave 2). Aborted. Not a cheap probe. |
+| E15 | **skipped** | Gated on Energy unlock. |
+| E16 | **skipped** | Gated on Energy unlock. |
+| E17 | **PASS** | Ranking unit fixtures green. Not a 100% claim. MATLAB cleanup comparator not re-run. |
+| E18 | **PASS** | MKL spike cannot replace the engine or emit `stretch_complete`. |
+| E19 | **PASS** | Full stretch without crop unlock refused; `(512,64,512)` is `incomplete_infra` before ULP. |
+| E20 | **skipped** | Gated on Energy unlock. |
+
+Parked next isolation (not this portfolio’s launch authority): one production-sized crop chunk (`stretch_energy_chunk_v202` vs MATLAB’s matching chunk). Runbook: [crop-energy-stretch-float-isolation.md](../solutions/parity/crop-energy-stretch-float-isolation.md).

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -13,6 +13,8 @@ Scoped initiatives: **requirements and implementation in one spec file** when wo
 | [phase-2-optimization-spec.md](phase-2-optimization-spec.md) | **Ideation / Draft** — blocked on Phase 1 Network green; do not unwind emulation early |
 | [random-component-parity-hardening-spec.md](../investigations/random-component-parity-hardening/random-component-parity-hardening-spec.md) | **Complete (archived)** — random-component suite hardening/refactor |
 | [random-component-references-deepening-plan.md](random-component-references-deepening-plan.md) | **Draft** — deepen the References module (follow-up) |
+| [2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md](2026-08-14-004-feat-true-zero-tolerance-parity-stretch-plan.md) | **Active stretch** — true zero-tolerance including Energy floats; Phase 1 stays CLOSED |
+| [2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md](2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md) | **E11–E20 portfolio** — crop Energy recorded `blocked_float_path`; U5/U6 gated |
 
 ## Workflow
 

--- a/docs/reference/core/EXACT_PROOF_FINDINGS.md
+++ b/docs/reference/core/EXACT_PROOF_FINDINGS.md
@@ -2,7 +2,7 @@
 
 [Up: Reference Docs](../README.md) · [Authority map](../../README.md#documentation-authority-map-one-concept--one-home) · [HANDOFF](../../../.claude/HANDOFF.md) · [TODO](../../TODO.md)
 
-**Last Updated:** 2026-08-14  
+**Last Updated:** 2026-08-16  
 **Role:** **Only** live source of truth for exact-route MATLAB↔Python parity status (runs, proofs, blockers, residual claim).  
 **Not here:** task checkboxes ([TODO](../../TODO.md)), operator commands ([HANDOFF](../../../.claude/HANDOFF.md)), figure paint constants ([parity_campaign_series.py](../../../figures/parity_campaign_series.py) — mirror KPIs only), investigation diary ([archive](../../investigations/exact-proof-findings-diary/README.md)).
 
@@ -67,7 +67,7 @@ This subsection tracks the post–Phase 1 **true zero-tolerance** program (bit-e
 
 Live stretch status is written beside stretch run artifacts (`stretch_status.json`), not into ONE TRUTH.
 
-**Session status (2026-08-15):** Crop Energy on `crop_M_stretch_engine_v1` finished via Python 3.7 + R2019a `matlab.engine`. `prove-exact --stage energy --strict-floats` **FAIL**: 2,623,250 / 4,194,304 voxels bit-identical (62.5%); scale indices match; max abs delta `1e-10`; mismatch ULP p50=1. Status **`blocked_float_path`** (not allclose success; no unlock). Remaining ULP is Python `interp3` after MATLAB `energy_filter_V200`. Next dest: `crop_M_stretch_engine_v2` with MATLAB `interp3` + scale-min in `stretch_energy_chunk_v202`. Do not start U5/U6 without Energy unlock. Phase 1 remains CLOSED on `canonical_full_v18`. Proof: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v1/03_Analysis/exact_proof_energy.json`.
+**Session status (2026-08-16):** Crop Energy `--strict-floats` remains **`blocked_float_path`**. Dest `crop_M_stretch_engine_v2` (MATLAB `stretch_energy_chunk_v202`: FFT + `energy_filter_V200` + `interp3` + scale-min) **FAIL**: 3,786,847 / 4,194,304 voxels bit-identical (90.3%); 407,457 mismatches; 0 scale mismatches; max abs delta `1e-10`; ULP p50=3, p90=9. Contrast v1 (filter-only, Python `interp3`): 62.5% bit-identical. E12 marshalling **PASS**. E13 named sources (linspace / Inf interp3 / tiny chunk-vs-full) bit-matched — isolation hypothesis **FAIL**. E14 whole-crop MATLAB `get_energy_V202` **deferred** (`incomplete_infra`: octave-chunked, aborted). E17–E19 unit guards **PASS**. E15/E16/E20 gated on Energy unlock. Do not relaunch v2. Do not start U5/U6. Allclose is not stretch success. Phase 1 remains CLOSED on `canonical_full_v18`. Proof: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v2/03_Analysis/exact_proof_energy.json`. Parked next isolation: one production-sized crop chunk vs MATLAB’s matching chunk. Runbook: [crop-energy-stretch-float-isolation.md](../../solutions/parity/crop-energy-stretch-float-isolation.md). Portfolio: [2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md](../../plans/2026-08-15-001-feat-zero-tolerance-stretch-experiments-plan.md).
 
 ---
 
@@ -129,5 +129,6 @@ Curated index of solved problems under `docs/solutions/`. Search via YAML frontm
 | Claimed energy trace provenance (ADR 0013) | [0013-claimed-energy-trace-provenance.md](../../adr/0013-claimed-energy-trace-provenance.md) |
 | Parity experiment hygiene | [parity-experiment-hygiene.md](../../solutions/best-practices/parity-experiment-hygiene.md) |
 | Curated vertices rank-ramp energies | [curated-vertices-rank-ramp-energies.md](../../solutions/integration-issues/curated-vertices-rank-ramp-energies.md) |
+| Crop Energy stretch float isolation (E11–E20; `blocked_float_path`) | [crop-energy-stretch-float-isolation.md](../../solutions/parity/crop-energy-stretch-float-isolation.md) |
 
 _Add rows here when a new compound doc is parity-relevant; do not duplicate full write-ups in this file._

--- a/docs/solutions/parity/crop-energy-stretch-float-isolation.md
+++ b/docs/solutions/parity/crop-energy-stretch-float-isolation.md
@@ -1,0 +1,64 @@
+---
+title: Crop Energy stretch float isolation (E11–E20)
+module: pipeline/energy
+tags: [energy, stretch, strict-floats, matlab-engine, blocked_float_path]
+problem_type: parity
+resolution_type: diagnosis
+---
+
+# Crop Energy stretch float isolation (E11–E20)
+
+## Problem
+
+True zero-tolerance stretch needs crop Energy bit-equal under
+`prove-exact --stage energy --strict-floats`. Phase 1 ADR 0011 allclose is
+already CLOSED and is **not** this bar. After MATLAB owned the per-chunk
+filter + `interp3` + scale-min body, crop Energy was still not bit-identical.
+
+## Evidence
+
+- v1 dest `crop_M_stretch_engine_v1` (MATLAB `energy_filter_V200`, Python
+  `interp3`): 2,623,250 / 4,194,304 bit-identical (62.5%).
+- v2 dest `crop_M_stretch_engine_v2` (`stretch_energy_chunk_v202`):
+  3,786,847 / 4,194,304 (90.3%); 407,457 mismatches; 0 scale mismatches;
+  max abs delta `1e-10`; ULP p50=3, p90=9.
+- Proof: `workspace/runs/oracle_180709_E/crop_M_stretch_engine_v2/03_Analysis/exact_proof_energy.json`
+- Status: `stretch_status.json` on that dest is `blocked_float_path`.
+
+Ruled out on cheap fixtures (engine skip = `incomplete_infra`, not fail):
+
+- E12: py37 `npy` → list → `matlab.double` roundtrip is bit-identical.
+- E13: linspace mesh, Inf `interp3`, and tiny chunk-vs-full bit-match.
+- E14: whole-crop MATLAB `get_energy_V202` is octave-chunked (726 chunks on
+  octave 2 of 6). Aborted as `incomplete_infra`. Not a cheap probe.
+
+## Root Cause
+
+Named leftover after E13: crop-scale FFT/filter vs the original MATLAB batch
+`get_energy_V202` (821-chunk lattice / oracle params), **not** transfer,
+linspace, or Inf interp3. The exact ULP source is **not** closed.
+
+## Solution
+
+Record **`blocked_float_path`**. Do not emit an Energy unlock. Do not treat
+90.3% or default allclose as stretch success. Do not relaunch v2. Do not
+overwrite `canonical_full_v18` or `crop_M_exact_v3`. U5/U6 stay gated.
+
+```powershell
+slavv parity inspect-proof --path workspace\runs\oracle_180709_E\crop_M_stretch_engine_v2\03_Analysis\exact_proof_energy.json
+```
+
+`(512, 64, 512)` vs oracle `(64, 512, 512)` is `incomplete_infra` before ULP
+(`classify_stretch_energy_orientation` in Energy compare).
+
+## Verification
+
+- E12/E13/E17/E18/E19 unit tests under `tests/unit/pipeline/energy/` and
+  `tests/unit/parity/` (engine tests skip without py37 + R2019a).
+- E11 prove already ran on v2; do not re-run the writer to “verify” this note.
+
+## Follow-Up
+
+One production-sized crop chunk (`stretch_energy_chunk_v202` vs MATLAB’s
+matching chunk), not another whole-crop Energy job. Live status stays in
+`stretch_status.json`, not ONE TRUTH.

--- a/scripts/stretch_get_energy_v202.m
+++ b/scripts/stretch_get_energy_v202.m
@@ -1,0 +1,36 @@
+function elapsed = stretch_get_energy_v202(matching_kernel_string, lumen_radius_in_microns_range, vessel_wall_thickness_in_microns, microns_per_voxel, pixels_per_sigma_PSF, max_voxels_per_node, data_directory, original_handle, energy_handle, gaussian_to_ideal_ratio, spherical_to_annular_ratio)
+%STRETCH_GET_ENERGY_V202 Scratch-only E14 wrapper. Python owns dest/I/O.
+% Force MATLAB get_energy_V202 orientations: radii column, microns/PSF 1x3 rows.
+lumen_radius_in_microns_range = double(lumen_radius_in_microns_range(:));
+microns_per_voxel = double(microns_per_voxel(:)).';
+pixels_per_sigma_PSF = double(pixels_per_sigma_PSF(:)).';
+vessel_wall_thickness_in_microns = double(vessel_wall_thickness_in_microns);
+max_voxels_per_node = double(max_voxels_per_node);
+gaussian_to_ideal_ratio = double(gaussian_to_ideal_ratio);
+spherical_to_annular_ratio = double(spherical_to_annular_ratio);
+data_directory = char(data_directory);
+original_handle = char(original_handle);
+energy_handle = char(energy_handle);
+matching_kernel_string = char(matching_kernel_string);
+
+log_path = fullfile(data_directory, 'e14_matlab.log');
+fid = fopen(log_path, 'a');
+if fid > 0
+    fprintf(fid, 'start %s radii=%d microns=[%g %g %g]\n', datestr(now, 30), ...
+        numel(lumen_radius_in_microns_range), microns_per_voxel(1), microns_per_voxel(2), microns_per_voxel(3));
+    fclose(fid);
+end
+tic;
+get_energy_V202( ...
+    matching_kernel_string, lumen_radius_in_microns_range, ...
+    vessel_wall_thickness_in_microns, microns_per_voxel, ...
+    pixels_per_sigma_PSF, max_voxels_per_node, data_directory, ...
+    original_handle, energy_handle, ...
+    gaussian_to_ideal_ratio, spherical_to_annular_ratio);
+elapsed = toc;
+fid = fopen(log_path, 'a');
+if fid > 0
+    fprintf(fid, 'done elapsed=%.3f\n', elapsed);
+    fclose(fid);
+end
+end

--- a/scripts/stretch_identity.m
+++ b/scripts/stretch_identity.m
@@ -1,0 +1,4 @@
+function y = stretch_identity(x)
+%STRETCH_IDENTITY Engine transfer identity for E12 marshalling probes.
+y = x;
+end

--- a/scripts/stretch_interp3_probe.m
+++ b/scripts/stretch_interp3_probe.m
@@ -1,0 +1,4 @@
+function out = stretch_interp3_probe(volume, mesh_x, mesh_y, mesh_z)
+%STRETCH_INTERP3_PROBE MATLAB interp3 with get_energy_V202 argument order.
+out = interp3(volume, mesh_x, mesh_y, mesh_z);
+end

--- a/scripts/stretch_linspace_1based.m
+++ b/scripts/stretch_linspace_1based.m
@@ -1,0 +1,8 @@
+function mesh = stretch_linspace_1based(offset, rf, count)
+%STRETCH_LINSPACE_1BASED Same linspace as stretch_energy_chunk_v202 / get_energy_V202.
+offset = double(offset);
+rf = double(rf);
+count = double(count);
+mesh = linspace(1 + mod(offset, rf) / rf, ...
+                1 + mod(offset, rf) / rf + (count - 1) / rf, count);
+end

--- a/scripts/stretch_matlab_engine_worker.py
+++ b/scripts/stretch_matlab_engine_worker.py
@@ -5,6 +5,8 @@ Must run under Python 3.7 (R2019a Engine ABI). Do not import slavv_python.
 Protocol: one JSON object per stdin line; one JSON object per stdout line.
 """
 
+# ruff: noqa: UP010, UP031, SIM105
+
 from __future__ import print_function
 
 import json
@@ -29,6 +31,24 @@ def _ok(payload=None):
 def _as_row(values):
     arr = np.asarray(values, dtype=np.float64).reshape(-1)
     return arr.tolist()
+
+
+def _to_matlab_double(matlab, array):
+    arr = np.asfortranarray(np.asarray(array, dtype=np.float64))
+    flat = [float(v) for v in np.ravel(arr, order="F")]
+    size = [int(d) for d in arr.shape]
+    try:
+        return matlab.double(flat, size=size)
+    except TypeError:
+        return matlab.double(flat)
+
+
+def _from_matlab_double(ml_array, shape):
+    data = getattr(ml_array, "_data", None)
+    if data is not None:
+        out = np.frombuffer(data, dtype=np.float64).copy()
+        return np.reshape(out, shape, order="F")
+    return np.asarray(ml_array, dtype=np.float64)
 
 
 def main():
@@ -70,13 +90,7 @@ def main():
                     continue
                 try:
                     chunk = np.load(str(msg["chunk_npy"]))
-                    chunk = np.asfortranarray(np.asarray(chunk, dtype=np.float64))
-                    flat = [float(v) for v in np.ravel(chunk, order="F")]
-                    size = [int(d) for d in chunk.shape]
-                    try:
-                        ml_chunk = matlab.double(flat, size=size)
-                    except TypeError:
-                        ml_chunk = matlab.double(flat)
+                    ml_chunk = _to_matlab_double(matlab, chunk)
                     microns = matlab.double(_as_row(msg["microns_per_pixel"]))
                     psf = matlab.double(_as_row(msg["pixels_per_sigma_psf"]))
                     energy = engine.stretch_energy_filter_v200(
@@ -100,12 +114,7 @@ def main():
                     y_len = int(msg["y1"]) - int(msg["y0"]) + 1
                     x_len = int(msg["x1"]) - int(msg["x0"]) + 1
                     z_len = int(msg["z1"]) - int(msg["z0"]) + 1
-                    data = getattr(energy, "_data", None)
-                    if data is not None:
-                        out = np.frombuffer(data, dtype=np.float64).copy()
-                        out = np.reshape(out, (y_len, x_len, z_len), order="F")
-                    else:
-                        out = np.asarray(energy, dtype=np.float64)
+                    out = _from_matlab_double(energy, (y_len, x_len, z_len))
                     out_path = str(msg["out_npy"])
                     np.save(out_path, np.ascontiguousarray(out))
                 except Exception as exc:
@@ -118,13 +127,7 @@ def main():
                     continue
                 try:
                     chunk = np.load(str(msg["chunk_npy"]))
-                    chunk = np.asfortranarray(np.asarray(chunk, dtype=np.float64))
-                    flat = [float(v) for v in np.ravel(chunk, order="F")]
-                    size = [int(d) for d in chunk.shape]
-                    try:
-                        ml_chunk = matlab.double(flat, size=size)
-                    except TypeError:
-                        ml_chunk = matlab.double(flat)
+                    ml_chunk = _to_matlab_double(matlab, chunk)
                     microns = matlab.double(_as_row(msg["microns_per_pixel"]))
                     psf = matlab.double(_as_row(msg["pixels_per_sigma_psf"]))
                     radii = matlab.double(_as_row(msg["radii"]))
@@ -159,18 +162,8 @@ def main():
                     x_len = int(msg["x_write_count"])
                     z_len = int(msg["z_write_count"])
                     out_shape = (y_len, x_len, z_len)
-                    energy_data = getattr(energy, "_data", None)
-                    if energy_data is not None:
-                        energy_out = np.frombuffer(energy_data, dtype=np.float64).copy()
-                        energy_out = np.reshape(energy_out, out_shape, order="F")
-                    else:
-                        energy_out = np.asarray(energy, dtype=np.float64)
-                    scale_data = getattr(scale_idx, "_data", None)
-                    if scale_data is not None:
-                        scale_out = np.frombuffer(scale_data, dtype=np.float64).copy()
-                        scale_out = np.reshape(scale_out, out_shape, order="F")
-                    else:
-                        scale_out = np.asarray(scale_idx, dtype=np.float64)
+                    energy_out = _from_matlab_double(energy, out_shape)
+                    scale_out = _from_matlab_double(scale_idx, out_shape)
                     energy_path = str(msg["energy_npy"])
                     scale_path = str(msg["scale_npy"])
                     np.save(energy_path, np.ascontiguousarray(energy_out))
@@ -179,6 +172,90 @@ def main():
                     _fail("energy_chunk failed: %s" % exc)
                     continue
                 _ok({"energy_npy": energy_path, "scale_npy": scale_path})
+            elif op == "roundtrip":
+                if engine is None:
+                    _fail("engine not started")
+                    continue
+                try:
+                    arr = np.load(str(msg["in_npy"]))
+                    arr = np.asfortranarray(np.asarray(arr, dtype=np.float64))
+                    ml_arr = _to_matlab_double(matlab, arr)
+                    ml_out = engine.stretch_identity(ml_arr, nargout=1)
+                    out_shape = tuple(int(d) for d in arr.shape)
+                    out = _from_matlab_double(ml_out, out_shape)
+                    out_path = str(msg["out_npy"])
+                    np.save(out_path, np.ascontiguousarray(out))
+                except Exception as exc:
+                    _fail("roundtrip failed: %s" % exc)
+                    continue
+                _ok({"out_npy": out_path})
+            elif op == "linspace_mesh":
+                if engine is None:
+                    _fail("engine not started")
+                    continue
+                try:
+                    mesh = engine.stretch_linspace_1based(
+                        float(msg["offset"]),
+                        float(msg["rf"]),
+                        float(msg["count"]),
+                        nargout=1,
+                    )
+                    count = int(msg["count"])
+                    out = _from_matlab_double(mesh, (count,))
+                    out_path = str(msg["out_npy"])
+                    np.save(out_path, np.ascontiguousarray(out.reshape(-1)))
+                except Exception as exc:
+                    _fail("linspace_mesh failed: %s" % exc)
+                    continue
+                _ok({"out_npy": out_path})
+            elif op == "interp3":
+                if engine is None:
+                    _fail("engine not started")
+                    continue
+                try:
+                    volume = np.load(str(msg["volume_npy"]))
+                    mesh_x = np.load(str(msg["mesh_x_npy"]))
+                    mesh_y = np.load(str(msg["mesh_y_npy"]))
+                    mesh_z = np.load(str(msg["mesh_z_npy"]))
+                    ml_volume = _to_matlab_double(matlab, volume)
+                    ml_x = _to_matlab_double(matlab, mesh_x)
+                    ml_y = _to_matlab_double(matlab, mesh_y)
+                    ml_z = _to_matlab_double(matlab, mesh_z)
+                    sampled = engine.stretch_interp3_probe(ml_volume, ml_x, ml_y, ml_z, nargout=1)
+                    out_shape = tuple(int(d) for d in np.asarray(mesh_y).shape)
+                    out = _from_matlab_double(sampled, out_shape)
+                    out_path = str(msg["out_npy"])
+                    np.save(out_path, np.ascontiguousarray(out))
+                except Exception as exc:
+                    _fail("interp3 failed: %s" % exc)
+                    continue
+                _ok({"out_npy": out_path})
+            elif op == "get_energy_v202":
+                if engine is None:
+                    _fail("engine not started")
+                    continue
+                try:
+                    radii = matlab.double(_as_row(msg["lumen_radius_in_microns_range"]))
+                    microns = matlab.double(_as_row(msg["microns_per_voxel"]))
+                    psf = matlab.double(_as_row(msg["pixels_per_sigma_psf"]))
+                    elapsed = engine.stretch_get_energy_v202(
+                        str(msg["matching_kernel_string"]),
+                        radii,
+                        float(msg["vessel_wall"]),
+                        microns,
+                        psf,
+                        float(msg["max_voxels_per_node"]),
+                        str(msg["data_directory"]),
+                        str(msg["original_handle"]),
+                        str(msg["energy_handle"]),
+                        float(msg["gaussian_to_ideal_ratio"]),
+                        float(msg["spherical_to_annular_ratio"]),
+                        nargout=1,
+                    )
+                except Exception as exc:
+                    _fail("get_energy_v202 failed: %s" % exc)
+                    continue
+                _ok({"elapsed_sec": float(elapsed)})
             elif op == "quit":
                 if engine is not None:
                     try:

--- a/scripts/stretch_whole_crop_get_energy_v202.py
+++ b/scripts/stretch_whole_crop_get_energy_v202.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python
+"""E14: scratch-only Python-orchestrated MATLAB get_energy_V202 vs crop oracle.
+
+Not a cheap probe: MATLAB get_energy_V202 is octave-chunked (726 chunks on
+octave 2 of 6 on crop_M). Abort / time-box rather than wait overnight.
+Isolation only — not a crop Energy unlock, not U5/U6, not stretch_complete.
+Never overwrites canonical_full_v18, crop_M_exact_v3, or crop_M_stretch_engine_v2.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import time
+from pathlib import Path
+
+import h5py
+import numpy as np
+from scipy.io import loadmat
+
+from slavv_python.analytics.parity.proof.energy_ulp_proof import (
+    EnergyFloatGateOptions,
+    evaluate_energy_float_gate,
+)
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    MatlabEngineInfraError,
+    default_vectorization_root,
+    refuse_matlab_only_energy_checkpoint_as_stretch_success,
+    refuse_protected_stretch_energy_dest,
+    resolve_matlab_root,
+)
+from slavv_python.pipeline.energy.matlab_engine_host import (
+    MatlabEnginePy37Worker,
+    resolve_python37_executable,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DEST = REPO_ROOT / "workspace" / "scratch" / "e14_whole_crop_get_energy_v202"
+ORACLE_BATCH = (
+    REPO_ROOT
+    / "workspace"
+    / "oracles"
+    / "180709_E_crop_M_v2"
+    / "01_Input"
+    / "matlab_results"
+    / "batch_260624-105705"
+)
+ORIGINAL_HANDLE = "original_180709_E_crop_M"
+ENERGY_HANDLE = "e14_energy_180709_E_crop_M"
+MATCHING_KERNEL = "3D gaussian conv annular pulse"
+CROP_VOXELS = 64 * 256 * 256
+TIMEBOX_SEC = 3600
+
+
+def _memory_check_crop() -> dict[str, float | int | bool]:
+    energy_bytes = CROP_VOXELS * 8 * 2
+    original_bytes = CROP_VOXELS * 2
+    ok = energy_bytes + original_bytes < 512 * 1024 * 1024
+    return {
+        "crop_voxels": CROP_VOXELS,
+        "approx_energy_bytes": energy_bytes,
+        "ok": ok,
+    }
+
+
+def _load_energy_settings(settings_path: Path) -> dict[str, object]:
+    payload = loadmat(settings_path, squeeze_me=True, struct_as_record=False)
+    return {
+        "lumen_radius_in_microns_range": np.asarray(
+            payload["lumen_radius_in_microns_range"], dtype=np.float64
+        ).reshape(-1),
+        "microns_per_voxel": np.asarray(payload["microns_per_voxel"], dtype=np.float64).reshape(-1),
+        "pixels_per_sigma_psf": np.asarray(
+            payload["pixels_per_sigma_PSF"], dtype=np.float64
+        ).reshape(-1),
+        "max_voxels_per_node": float(payload["max_voxels_per_node_energy"]),
+        "gaussian_to_ideal_ratio": float(payload["gaussian_to_ideal_ratio"]),
+        "spherical_to_annular_ratio": float(payload["spherical_to_annular_ratio"]),
+        "vessel_wall": 0.0,
+    }
+
+
+def _load_energy_hdf5(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    with h5py.File(path, "r") as handle:
+        planes = np.asarray(handle["d"], dtype=np.float64)
+    if planes.ndim != 4 or planes.shape[0] < 2:
+        raise ValueError(f"unexpected MATLAB energy HDF5 shape {planes.shape} for {path}")
+    return planes, planes[1], planes[0]
+
+
+def _compare_to_oracle(oracle_path: Path, e14_path: Path) -> dict[str, object]:
+    oracle_planes, oracle_energy, oracle_scales = _load_energy_hdf5(oracle_path)
+    e14_planes, e14_energy, e14_scales = _load_energy_hdf5(e14_path)
+    raw_equal = bool(
+        oracle_planes.shape == e14_planes.shape and np.array_equal(oracle_planes, e14_planes)
+    )
+    gate = evaluate_energy_float_gate(
+        oracle_energy,
+        e14_energy,
+        oracle_scales,
+        e14_scales,
+        options=EnergyFloatGateOptions(strict_floats=True, use_allclose=False),
+    )
+    return {
+        "raw_hdf5_bit_identical": raw_equal,
+        "oracle_shape": list(oracle_planes.shape),
+        "e14_shape": list(e14_planes.shape),
+        "energy_float_gate": gate,
+        "isolation_only": True,
+        "not_stretch_success": True,
+        "allclose_is_not_stretch_success": True,
+    }
+
+
+def run_e14(*, dest: Path, timebox_sec: int = TIMEBOX_SEC) -> dict[str, object]:
+    refuse_protected_stretch_energy_dest(dest)
+    memory = _memory_check_crop()
+    if not bool(memory["ok"]):
+        return {
+            "result": "deferred",
+            "status_class": "incomplete_infra",
+            "reason": "crop Energy memory check failed",
+            "memory": memory,
+        }
+    original_src = ORACLE_BATCH / "data" / ORIGINAL_HANDLE
+    oracle_energy = ORACLE_BATCH / "data" / "energy_260624-105705_180709_E_crop_M"
+    settings_path = ORACLE_BATCH / "settings" / "energy_260624-105705.mat"
+    if not original_src.is_file() or not oracle_energy.is_file() or not settings_path.is_file():
+        return {
+            "result": "skip",
+            "status_class": "incomplete_infra",
+            "reason": "crop original / oracle Energy / settings missing",
+        }
+    python37 = resolve_python37_executable()
+    if python37 is None:
+        return {
+            "result": "skip",
+            "status_class": "incomplete_infra",
+            "reason": "isolated Python 3.7 stretch env missing",
+        }
+    try:
+        resolve_matlab_root()
+    except MatlabEngineInfraError as exc:
+        return {"result": "skip", "status_class": "incomplete_infra", "reason": str(exc)}
+
+    dest.mkdir(parents=True, exist_ok=True)
+    original_dest = dest / ORIGINAL_HANDLE
+    if not original_dest.is_file():
+        shutil.copy2(original_src, original_dest)
+    energy_out = dest / ENERGY_HANDLE
+    if energy_out.exists():
+        energy_out.unlink()
+
+    params = _load_energy_settings(settings_path)
+    started = dest / "e14_started.json"
+    started.write_text(
+        json.dumps({"started_at": time.time(), "timebox_sec": timebox_sec}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    vectorization_root = default_vectorization_root()
+    worker = MatlabEnginePy37Worker(python37, vectorization_root=vectorization_root)
+    t0 = time.time()
+    try:
+        worker.start()
+        elapsed = worker.get_energy_v202(
+            matching_kernel_string=MATCHING_KERNEL,
+            lumen_radius_in_microns_range=np.asarray(
+                params["lumen_radius_in_microns_range"], dtype=np.float64
+            ),
+            vessel_wall=float(params["vessel_wall"]),
+            microns_per_voxel=np.asarray(params["microns_per_voxel"], dtype=np.float64),
+            pixels_per_sigma_psf=np.asarray(params["pixels_per_sigma_psf"], dtype=np.float64),
+            max_voxels_per_node=float(params["max_voxels_per_node"]),
+            data_directory=dest,
+            original_handle=ORIGINAL_HANDLE,
+            energy_handle=ENERGY_HANDLE,
+            gaussian_to_ideal_ratio=float(params["gaussian_to_ideal_ratio"]),
+            spherical_to_annular_ratio=float(params["spherical_to_annular_ratio"]),
+        )
+    except MatlabEngineInfraError as exc:
+        return {
+            "result": "skip",
+            "status_class": "incomplete_infra",
+            "reason": str(exc),
+            "wall_sec": time.time() - t0,
+        }
+    finally:
+        worker.quit()
+    wall_sec = time.time() - t0
+    if wall_sec > timebox_sec:
+        return {
+            "result": "deferred",
+            "status_class": "incomplete_infra",
+            "reason": f"E14 exceeded timebox {timebox_sec}s (wall {wall_sec:.1f}s)",
+            "matlab_elapsed_sec": elapsed,
+            "wall_sec": wall_sec,
+        }
+    if not energy_out.is_file():
+        return {
+            "result": "fail",
+            "reason": "MATLAB get_energy_V202 did not write Energy HDF5",
+            "matlab_elapsed_sec": elapsed,
+            "wall_sec": wall_sec,
+        }
+    compare = _compare_to_oracle(oracle_energy, energy_out)
+    gate = compare["energy_float_gate"]
+    passed = bool(compare["raw_hdf5_bit_identical"]) and bool(gate.get("passed"))
+    interpretation = (
+        "MATLAB get_energy_V202 via engine matches oracle; residual is the chunked "
+        "Python-orchestrated stretch_energy_chunk_v202 / 821-chunk lattice"
+        if passed
+        else "MATLAB get_energy_V202 via engine also mismatches oracle "
+        "(oracle/params/orientation/batch provenance), not only the chunk helper"
+    )
+    return {
+        "result": "pass" if passed else "fail",
+        "interpretation": interpretation,
+        "isolation_only": True,
+        "not_stretch_success": True,
+        "matlab_elapsed_sec": elapsed,
+        "wall_sec": wall_sec,
+        "memory": memory,
+        "compare": compare,
+        "dest": str(dest),
+        "oracle_energy": str(oracle_energy),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dest", type=Path, default=DEFAULT_DEST)
+    parser.add_argument("--timebox-sec", type=int, default=TIMEBOX_SEC)
+    parser.add_argument(
+        "--claim-matlab-only-success",
+        action="store_true",
+        help="forbidden: MATLAB-only Energy is not stretch success (R6)",
+    )
+    args = parser.parse_args(argv)
+    if args.claim_matlab_only_success:
+        refuse_matlab_only_energy_checkpoint_as_stretch_success()
+    payload = run_e14(dest=args.dest, timebox_sec=int(args.timebox_sec))
+    out_path = Path(args.dest) / "e14_result.json"
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, default=str) + "\n", encoding="utf-8")
+    print(json.dumps({"result": payload.get("result"), "path": str(out_path)}, indent=2))
+    if payload.get("result") == "pass":
+        return 0
+    if payload.get("result") in {"skip", "deferred"}:
+        return 2
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/slavv_python/analytics/parity/proof/artifact_comparator.py
+++ b/slavv_python/analytics/parity/proof/artifact_comparator.py
@@ -14,6 +14,7 @@ from slavv_python.analytics.parity.proof.energy_ulp_proof import (
     evaluate_energy_float_gate,
 )
 from slavv_python.analytics.parity.proof.exact_proof_contract import EXACT_STAGE_FIELDS
+from slavv_python.analytics.parity.proof.stretch import classify_stretch_energy_orientation
 
 # ADR 0012: minimum ownership-map agreement fraction for edges parity bar
 _ADR0012_OWNERSHIP_THRESHOLD = 0.60
@@ -373,9 +374,35 @@ def _compare_energy_stage(
     float_tol: tuple[float, float] | None = None,
 ) -> tuple[dict[str, Any] | None, dict[str, Any]]:
     """Compare Energy stage with ADR 0011 float policy on energy.energy only."""
+    matlab_energy = np.asarray(matlab_payload["energy"])
+    python_energy = np.asarray(python_payload["energy"])
+    orientation = classify_stretch_energy_orientation(
+        energy_shape=tuple(python_energy.shape),
+        oracle_shape=tuple(matlab_energy.shape),
+    )
+    if orientation is not None:
+        gate_summary = {
+            "passed": False,
+            "strict_floats": energy_float_options.strict_floats,
+            "use_allclose": energy_float_options.use_allclose,
+            "incomplete_infra": True,
+            "orientation_refuse": True,
+            "status": orientation.status.value,
+            "failures": [orientation.reason],
+        }
+        return (
+            _mismatch(
+                "energy",
+                "energy.energy",
+                "incomplete_infra orientation",
+                matlab_payload["energy"],
+                python_payload["energy"],
+            ),
+            gate_summary,
+        )
     gate_summary = evaluate_energy_float_gate(
-        np.asarray(matlab_payload["energy"]),
-        np.asarray(python_payload["energy"]),
+        matlab_energy,
+        python_energy,
         np.asarray(matlab_payload["scale_indices"]),
         np.asarray(python_payload["scale_indices"]),
         options=energy_float_options,

--- a/slavv_python/analytics/parity/proof/stretch.py
+++ b/slavv_python/analytics/parity/proof/stretch.py
@@ -135,6 +135,40 @@ def field_set_covers(have: StretchFieldSet, need: StretchFieldSet) -> bool:
     return have == StretchFieldSet.ENERGY_AND_DISCRETE
 
 
+def classify_stretch_energy_orientation(
+    *,
+    energy_shape: tuple[int, ...],
+    oracle_shape: tuple[int, ...],
+) -> StretchGateDecision | None:
+    """Refuse orientation-swapped Energy before ULP accounting (E19).
+
+    A ``(512, 64, 512)`` checkpoint vs oracle ``(64, 512, 512)`` is
+    ``incomplete_infra``, not a float-bar near-miss.
+    """
+    energy = tuple(int(dim) for dim in energy_shape)
+    oracle = tuple(int(dim) for dim in oracle_shape)
+    if energy == oracle:
+        return None
+    swapped_hw = (
+        len(energy) == 3
+        and len(oracle) == 3
+        and energy[0] == oracle[1]
+        and energy[1] == oracle[0]
+        and energy[2] == oracle[2]
+    )
+    reason = (
+        f"Energy shape {energy} looks like an orientation swap vs oracle {oracle}; "
+        "refuse before ULP accounting (incomplete_infra)"
+        if swapped_hw
+        else f"Energy shape {energy} != oracle {oracle}; refuse before ULP (incomplete_infra)"
+    )
+    return StretchGateDecision(
+        allowed=False,
+        status=StretchStatus.INCOMPLETE_INFRA,
+        reason=reason,
+    )
+
+
 def write_stretch_unlock(
     path: Path,
     *,

--- a/slavv_python/pipeline/energy/matlab_engine_backend.py
+++ b/slavv_python/pipeline/energy/matlab_engine_backend.py
@@ -163,6 +163,29 @@ def refuse_matlab_only_energy_checkpoint_as_stretch_success() -> None:
     )
 
 
+# E14 / stretch writers must never overwrite these dest names (plan R10 / R14).
+PROTECTED_STRETCH_DEST_NAMES = frozenset(
+    {
+        "canonical_full_v18",
+        "crop_M_exact_v3",
+        "crop_M_stretch_engine_v2",
+    }
+)
+
+
+def refuse_protected_stretch_energy_dest(dest_run_root: Path) -> None:
+    """Refuse E14/scratch Energy dests that would overwrite protected run roots."""
+    dest = Path(dest_run_root)
+    hit = next(
+        (part for part in dest.parts if part in PROTECTED_STRETCH_DEST_NAMES),
+        None,
+    )
+    if hit is not None:
+        raise MatlabEnginePolicyError(
+            f"refusing stretch Energy dest that overwrites protected root {hit}"
+        )
+
+
 def ensure_matlab_engine_float_backend_ready(config: dict[str, Any]) -> None:
     """Refuse NumPy float-body execution under ``energy_float_backend=matlab_engine``.
 

--- a/slavv_python/pipeline/energy/matlab_engine_host.py
+++ b/slavv_python/pipeline/energy/matlab_engine_host.py
@@ -193,7 +193,6 @@ class MatlabEnginePy37Worker:
         try:
             proc.stdin.write(json.dumps(payload) + "\n")
             proc.stdin.flush()
-            line = proc.stdout.readline()
         except OSError as exc:
             err = ""
             if proc.stderr is not None:
@@ -201,20 +200,38 @@ class MatlabEnginePy37Worker:
             raise MatlabEngineInfraError(
                 f"Python 3.7 MATLAB worker I/O failed: {exc}; stderr={err!r}"
             ) from exc
-        if not line:
-            err = ""
-            if proc.stderr is not None:
-                err = proc.stderr.read()
-            raise MatlabEngineInfraError(f"Python 3.7 MATLAB worker exited; stderr={err!r}")
-        try:
-            reply = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise MatlabEngineInfraError(
-                f"Python 3.7 MATLAB worker returned non-JSON: {line!r}"
-            ) from exc
-        if not isinstance(reply, dict):
-            raise MatlabEngineInfraError("Python 3.7 MATLAB worker reply must be an object")
-        return reply
+        # MATLAB parpool / fprintf may land on the worker stdout. Skip until JSON.
+        skipped: list[str] = []
+        while True:
+            try:
+                line = proc.stdout.readline()
+            except OSError as exc:
+                err = ""
+                if proc.stderr is not None:
+                    err = proc.stderr.read()
+                raise MatlabEngineInfraError(
+                    f"Python 3.7 MATLAB worker I/O failed: {exc}; stderr={err!r}"
+                ) from exc
+            if not line:
+                err = ""
+                if proc.stderr is not None:
+                    err = proc.stderr.read()
+                noise = " | ".join(skipped[-5:])
+                raise MatlabEngineInfraError(
+                    f"Python 3.7 MATLAB worker exited; stderr={err!r}; stdout_noise={noise!r}"
+                )
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                reply = json.loads(stripped)
+            except json.JSONDecodeError:
+                skipped.append(stripped[:200])
+                logger.info("stretch worker stdout (non-JSON): %s", stripped[:200])
+                continue
+            if not isinstance(reply, dict):
+                raise MatlabEngineInfraError("Python 3.7 MATLAB worker reply must be an object")
+            return reply
 
     def energy_filter_v200_from_spatial(
         self,
@@ -342,6 +359,133 @@ class MatlabEnginePy37Worker:
         energy = np.ascontiguousarray(np.asarray(np.load(energy_path), dtype=np.float64))
         scale_idx = np.ascontiguousarray(np.asarray(np.load(scale_path), dtype=np.float64))
         return energy, scale_idx
+
+    def roundtrip_float64(self, array: np.ndarray) -> np.ndarray:
+        """Identity through production worker ``matlab.double`` marshalling (E12)."""
+        if self._tmpdir is None:
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker tempdir missing")
+        work = Path(self._tmpdir.name)
+        in_path = work / "roundtrip_in.npy"
+        out_path = work / "roundtrip_out.npy"
+        np.save(in_path, np.asfortranarray(np.asarray(array, dtype=np.float64)))
+        reply = self._request(
+            {
+                "op": "roundtrip",
+                "in_npy": str(in_path),
+                "out_npy": str(out_path),
+            }
+        )
+        if not reply.get("ok"):
+            raise MatlabEngineInfraError(f"roundtrip worker call failed: {reply.get('error')}")
+        restored = np.load(out_path)
+        return cast("np.ndarray", np.ascontiguousarray(np.asarray(restored, dtype=np.float64)))
+
+    def linspace_1based(self, offset: int, rf: int, count: int) -> np.ndarray:
+        """MATLAB ``linspace`` mesh from stretch_energy_chunk_v202 / get_energy_V202."""
+        if self._tmpdir is None:
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker tempdir missing")
+        work = Path(self._tmpdir.name)
+        out_path = work / "linspace_mesh.npy"
+        reply = self._request(
+            {
+                "op": "linspace_mesh",
+                "offset": int(offset),
+                "rf": int(rf),
+                "count": int(count),
+                "out_npy": str(out_path),
+            }
+        )
+        if not reply.get("ok"):
+            raise MatlabEngineInfraError(f"linspace_mesh worker call failed: {reply.get('error')}")
+        mesh = np.load(out_path)
+        return cast(
+            "np.ndarray", np.ascontiguousarray(np.asarray(mesh, dtype=np.float64).reshape(-1))
+        )
+
+    def interp3_probe(
+        self,
+        volume: np.ndarray,
+        mesh_x: np.ndarray,
+        mesh_y: np.ndarray,
+        mesh_z: np.ndarray,
+    ) -> np.ndarray:
+        """MATLAB ``interp3(volume, mesh_X, mesh_Y, mesh_Z)`` via worker marshalling."""
+        if self._tmpdir is None:
+            raise MatlabEngineInfraError("Python 3.7 MATLAB worker tempdir missing")
+        work = Path(self._tmpdir.name)
+        volume_path = work / "interp3_volume.npy"
+        mesh_x_path = work / "interp3_mesh_x.npy"
+        mesh_y_path = work / "interp3_mesh_y.npy"
+        mesh_z_path = work / "interp3_mesh_z.npy"
+        out_path = work / "interp3_out.npy"
+        np.save(volume_path, np.asfortranarray(np.asarray(volume, dtype=np.float64)))
+        np.save(mesh_x_path, np.asfortranarray(np.asarray(mesh_x, dtype=np.float64)))
+        np.save(mesh_y_path, np.asfortranarray(np.asarray(mesh_y, dtype=np.float64)))
+        np.save(mesh_z_path, np.asfortranarray(np.asarray(mesh_z, dtype=np.float64)))
+        reply = self._request(
+            {
+                "op": "interp3",
+                "volume_npy": str(volume_path),
+                "mesh_x_npy": str(mesh_x_path),
+                "mesh_y_npy": str(mesh_y_path),
+                "mesh_z_npy": str(mesh_z_path),
+                "out_npy": str(out_path),
+            }
+        )
+        if not reply.get("ok"):
+            raise MatlabEngineInfraError(f"interp3 worker call failed: {reply.get('error')}")
+        sampled = np.load(out_path)
+        return cast("np.ndarray", np.ascontiguousarray(np.asarray(sampled, dtype=np.float64)))
+
+    def get_energy_v202(
+        self,
+        *,
+        matching_kernel_string: str,
+        lumen_radius_in_microns_range: np.ndarray,
+        vessel_wall: float,
+        microns_per_voxel: np.ndarray,
+        pixels_per_sigma_psf: np.ndarray,
+        max_voxels_per_node: float,
+        data_directory: Path,
+        original_handle: str,
+        energy_handle: str,
+        gaussian_to_ideal_ratio: float,
+        spherical_to_annular_ratio: float,
+    ) -> float:
+        """Call MATLAB ``get_energy_V202`` on HDF5 files already on disk (E14)."""
+        data_dir = Path(data_directory)
+        directory = str(data_dir)
+        if not directory.endswith(("\\", "/")):
+            directory = directory + os.sep
+        reply = self._request(
+            {
+                "op": "get_energy_v202",
+                "matching_kernel_string": str(matching_kernel_string),
+                "lumen_radius_in_microns_range": np.asarray(
+                    lumen_radius_in_microns_range, dtype=np.float64
+                )
+                .reshape(-1)
+                .tolist(),
+                "vessel_wall": float(vessel_wall),
+                "microns_per_voxel": np.asarray(microns_per_voxel, dtype=np.float64)
+                .reshape(-1)
+                .tolist(),
+                "pixels_per_sigma_psf": np.asarray(pixels_per_sigma_psf, dtype=np.float64)
+                .reshape(-1)
+                .tolist(),
+                "max_voxels_per_node": float(max_voxels_per_node),
+                "data_directory": directory,
+                "original_handle": str(original_handle),
+                "energy_handle": str(energy_handle),
+                "gaussian_to_ideal_ratio": float(gaussian_to_ideal_ratio),
+                "spherical_to_annular_ratio": float(spherical_to_annular_ratio),
+            }
+        )
+        if not reply.get("ok"):
+            raise MatlabEngineInfraError(
+                f"get_energy_V202 worker call failed: {reply.get('error')}"
+            )
+        return float(reply.get("elapsed_sec", 0.0))
 
 
 def energy_filter_v200_from_spatial(

--- a/tests/unit/parity/test_stretch_full_volume_gate.py
+++ b/tests/unit/parity/test_stretch_full_volume_gate.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 from pathlib import Path  # noqa: TC003
 
+import numpy as np
+
+from slavv_python.analytics.parity.proof.artifact_comparator import compare_exact_artifacts
+from slavv_python.analytics.parity.proof.energy_ulp_proof import EnergyFloatGateOptions
 from slavv_python.analytics.parity.proof.stretch import (
     PHASE1_CLAIM_RUN_NAME,
     StretchFieldSet,
     StretchStatus,
+    classify_stretch_energy_orientation,
     gate_full_stretch_entry,
     write_stretch_status,
     write_stretch_unlock,
@@ -66,3 +71,52 @@ def test_refuse_overwrite_phase1_claim_root(tmp_path: Path) -> None:
     )
     assert decision.allowed is False
     assert PHASE1_CLAIM_RUN_NAME in decision.reason
+
+
+def test_orientation_512_64_512_is_infra_not_float_bar() -> None:
+    decision = classify_stretch_energy_orientation(
+        energy_shape=(512, 64, 512),
+        oracle_shape=(64, 512, 512),
+    )
+    assert decision is not None
+    assert decision.allowed is False
+    assert decision.status == StretchStatus.INCOMPLETE_INFRA
+    assert "orientation" in decision.reason
+
+
+def test_matching_energy_shape_is_not_orientation_refuse() -> None:
+    assert (
+        classify_stretch_energy_orientation(
+            energy_shape=(64, 256, 256),
+            oracle_shape=(64, 256, 256),
+        )
+        is None
+    )
+
+
+def test_energy_compare_refuses_orientation_before_ulp() -> None:
+    oracle = np.zeros((2, 4, 4), dtype=np.float64)
+    swapped = np.zeros((4, 2, 4), dtype=np.float64)
+    payload_oracle = {
+        "energy": oracle,
+        "scale_indices": np.ones((2, 4, 4), dtype=np.int64),
+        "energy_4d": np.empty((0, 0, 0, 0), dtype=np.float64),
+        "lumen_radius_microns": np.array([1.0], dtype=np.float64),
+    }
+    payload_swapped = {
+        **payload_oracle,
+        "energy": swapped,
+        "scale_indices": np.ones((4, 2, 4), dtype=np.int64),
+    }
+    report = compare_exact_artifacts(
+        {"energy": payload_oracle},
+        {"energy": payload_swapped},
+        ("energy",),
+        energy_float_options=EnergyFloatGateOptions(strict_floats=True),
+    )
+    assert report["passed"] is False
+    gate = report["energy_float_gate"]
+    assert gate["incomplete_infra"] is True
+    assert gate["orientation_refuse"] is True
+    assert "ulp_stats_on_mismatches" not in gate
+    assert report["first_failure"]["mismatch_type"] == "incomplete_infra orientation"

--- a/tests/unit/pipeline/energy/conftest.py
+++ b/tests/unit/pipeline/energy/conftest.py
@@ -1,0 +1,41 @@
+"""Shared MATLAB-engine fixtures for stretch Energy isolation tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator  # noqa: TC003
+
+import pytest
+
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    MatlabEngineInfraError,
+    default_vectorization_root,
+    resolve_matlab_root,
+)
+from slavv_python.pipeline.energy.matlab_engine_host import (
+    MatlabEnginePy37Worker,
+    resolve_python37_executable,
+)
+
+
+@pytest.fixture(scope="session")
+def stretch_py37_worker() -> Iterator[MatlabEnginePy37Worker]:
+    """Long-lived py37 MATLAB worker, or skip as incomplete_infra."""
+    python37 = resolve_python37_executable()
+    if python37 is None:
+        pytest.skip("incomplete_infra: isolated Python 3.7 stretch env missing")
+    try:
+        resolve_matlab_root()
+    except MatlabEngineInfraError as exc:
+        pytest.skip(f"incomplete_infra: {exc}")
+    vectorization_root = default_vectorization_root()
+    if not (vectorization_root / "source").is_dir():
+        pytest.skip("incomplete_infra: Vectorization-Public source missing")
+    worker = MatlabEnginePy37Worker(python37, vectorization_root=vectorization_root)
+    try:
+        worker.start()
+    except MatlabEngineInfraError as exc:
+        pytest.skip(f"incomplete_infra: {exc}")
+    try:
+        yield worker
+    finally:
+        worker.quit()

--- a/tests/unit/pipeline/energy/test_stretch_ulp_isolation.py
+++ b/tests/unit/pipeline/energy/test_stretch_ulp_isolation.py
@@ -1,0 +1,224 @@
+"""E13: remaining Energy ULP isolation (linspace, Inf/NaN interp3, chunk vs full)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from slavv_python.pipeline.energy.config import _prepare_energy_config
+from slavv_python.pipeline.energy.matlab_get_energy_v202_chunked import (
+    _interp3_matlab_linear_inf,
+    _matlab_zero_based_linspace_raw,
+    compute_exact_parity_energy_chunked,
+    get_chunking_lattice_v190,
+)
+from slavv_python.utils.validation import validate_parameters
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CHUNK_HELPER = REPO_ROOT / "scripts" / "stretch_energy_chunk_v202.m"
+GET_ENERGY = REPO_ROOT / "external" / "Vectorization-Public" / "source" / "get_energy_V202.m"
+
+
+def _compact_matlab(source: str) -> str:
+    return "".join(source.split())
+
+
+def test_e13_linspace_formula_matches_get_energy_v202() -> None:
+    chunk_src = _compact_matlab(CHUNK_HELPER.read_text(encoding="utf-8"))
+    full_src = _compact_matlab(GET_ENERGY.read_text(encoding="utf-8"))
+    chunk_token = "linspace(1+mod("
+    full_token = "linspace(1+mod("
+    assert chunk_token in chunk_src, f"stretch helper missing linspace mod formula: {CHUNK_HELPER}"
+    assert full_token in full_src, f"get_energy_V202 missing linspace mod formula: {GET_ENERGY}"
+    assert "+(yw-1)/rf(1),yw)" in chunk_src
+    assert "writing_counts" in full_src
+    assert "resolution_factors" in full_src
+
+
+def test_e13_python_linspace_matches_matlab_engine(stretch_py37_worker) -> None:
+    cases = (
+        (0, 3, 128, 0),
+        (51, 3, 51, 17),
+        (73, 3, 52, 24),
+        (0, 2, 8, 0),
+    )
+    mismatches = 0
+    compared = 0
+    for offset, stride, count, local_start in cases:
+        matlab_1based = stretch_py37_worker.linspace_1based(offset, stride, count)
+        python_0based = _matlab_zero_based_linspace_raw(offset, stride, count, local_start)
+        matlab_0based = matlab_1based - 1.0
+        compared += int(count)
+        if not np.array_equal(matlab_0based, python_0based):
+            mismatches += int(np.count_nonzero(matlab_0based != python_0based))
+    assert mismatches == 0, (
+        f"E13 linspace isolation: {mismatches}/{compared} samples differ "
+        "(named source: linspace mesh endpoints)"
+    )
+
+
+def _interp3_values_match(matlab_value: float, python_value: float) -> bool:
+    if np.isnan(matlab_value) and np.isnan(python_value):
+        return True
+    if np.isposinf(matlab_value) and np.isposinf(python_value):
+        return True
+    if np.isneginf(matlab_value) and np.isneginf(python_value):
+        return True
+    return bool(
+        np.isfinite(matlab_value) and np.isfinite(python_value) and matlab_value == python_value
+    )
+
+
+def test_e13_inf_nan_interp3_matches_matlab_engine(stretch_py37_worker) -> None:
+    volume = np.full((2, 2, 2), np.inf, dtype=np.float64)
+    volume[0, 0, 0] = -6.0
+
+    queries = (
+        (0.0, 0.0, 0.0),
+        (0.5, 0.0, 0.0),
+        (0.0, 0.5, 0.0),
+        (0.5, 0.5, 0.5),
+    )
+    mismatches: list[str] = []
+    for y, x, z in queries:
+        matlab_out = stretch_py37_worker.interp3_probe(
+            volume,
+            np.array([[[x + 1.0]]], dtype=np.float64),
+            np.array([[[y + 1.0]]], dtype=np.float64),
+            np.array([[[z + 1.0]]], dtype=np.float64),
+        )
+        python_out = _interp3_matlab_linear_inf(
+            volume,
+            (
+                np.array([[[y]]], dtype=np.float64),
+                np.array([[[x]]], dtype=np.float64),
+                np.array([[[z]]], dtype=np.float64),
+            ),
+        )
+        ml = float(np.asarray(matlab_out).reshape(-1)[0])
+        py = float(np.asarray(python_out).reshape(-1)[0])
+        if not _interp3_values_match(ml, py):
+            mismatches.append(f"y={y} x={x} z={z} matlab={ml} python={py}")
+    assert not mismatches, "E13 Inf interp3 MATLAB vs Python helper diverged: " + "; ".join(
+        mismatches
+    )
+
+
+def test_e13_nan_interp3_divergence_is_not_tiny_ulp(stretch_py37_worker) -> None:
+    volume = np.zeros((2, 2, 2), dtype=np.float64)
+    volume[1, 1, 1] = np.nan
+    matlab_out = stretch_py37_worker.interp3_probe(
+        volume,
+        np.array([[[2.0]]], dtype=np.float64),
+        np.array([[[2.0]]], dtype=np.float64),
+        np.array([[[2.0]]], dtype=np.float64),
+    )
+    python_out = _interp3_matlab_linear_inf(
+        volume,
+        (
+            np.array([[[1.0]]], dtype=np.float64),
+            np.array([[[1.0]]], dtype=np.float64),
+            np.array([[[1.0]]], dtype=np.float64),
+        ),
+    )
+    ml = float(np.asarray(matlab_out).reshape(-1)[0])
+    py = float(np.asarray(python_out).reshape(-1)[0])
+    if _interp3_values_match(ml, py):
+        return
+    assert np.isnan(ml) or np.isnan(py) or np.isinf(ml) or np.isinf(py), (
+        f"NaN interp3 diverged as tiny ULP matlab={ml} python={py}; "
+        "that would be a v2-like residual, not an Inf/NaN class gap"
+    )
+
+
+def test_e13_inf_interp3_positive_weight_matches_known_python_fixture(
+    stretch_py37_worker,
+) -> None:
+    volume = np.full((2, 2, 2), np.inf, dtype=np.float64)
+    volume[0, 0, 0] = -6.0
+    matlab_corner = stretch_py37_worker.interp3_probe(
+        volume,
+        np.array([[[1.0]]], dtype=np.float64),
+        np.array([[[1.0]]], dtype=np.float64),
+        np.array([[[1.0]]], dtype=np.float64),
+    )
+    matlab_half = stretch_py37_worker.interp3_probe(
+        volume,
+        np.array([[[1.0]]], dtype=np.float64),
+        np.array([[[1.5]]], dtype=np.float64),
+        np.array([[[1.0]]], dtype=np.float64),
+    )
+    python_corner = _interp3_matlab_linear_inf(
+        volume,
+        (
+            np.array([[[0.0]]], dtype=np.float64),
+            np.array([[[0.0]]], dtype=np.float64),
+            np.array([[[0.0]]], dtype=np.float64),
+        ),
+    )
+    python_half = _interp3_matlab_linear_inf(
+        volume,
+        (
+            np.array([[[0.5]]], dtype=np.float64),
+            np.array([[[0.0]]], dtype=np.float64),
+            np.array([[[0.0]]], dtype=np.float64),
+        ),
+    )
+    assert float(matlab_corner.reshape(-1)[0]) == float(python_corner.reshape(-1)[0]) == -6.0
+    assert np.isposinf(matlab_half.reshape(-1)[0])
+    assert np.isposinf(python_half.reshape(-1)[0])
+
+
+def test_e13_chunk_vs_full_tiny_engine_body(stretch_py37_worker) -> None:
+    rng = np.random.default_rng(13)
+    image = np.asfortranarray(rng.random((8, 8, 8), dtype=np.float64))
+    shared = {
+        "energy_method": "hessian",
+        "energy_float_backend": "matlab_engine",
+        "comparison_exact_network": True,
+        "n_jobs": 1,
+        "radius_of_smallest_vessel_in_microns": 1.5,
+        "radius_of_largest_vessel_in_microns": 1.6,
+    }
+
+    def _bound_config(max_voxels: float) -> dict:
+        params = validate_parameters({**shared, "max_voxels_per_node_energy": max_voxels})
+        params["_stretch_engine_float_body_bound"] = True
+        params["_stretch_engine_session"] = stretch_py37_worker
+        return _prepare_energy_config(image, params)
+
+    config_full = _bound_config(1e9)
+    config_chunked = _bound_config(64.0)
+    image_shape = np.asarray(image.shape, dtype=float)
+    planned_shape = np.array([image_shape[1], image_shape[2], image_shape[0]], dtype=float)
+    microns = np.asarray(config_chunked["microns_per_voxel"], dtype=float)
+    _, n_chunks = get_chunking_lattice_v190(
+        1.0 / np.array([microns[1], microns[2], microns[0]]),
+        float(config_chunked["max_voxels"]),
+        np.round(planned_shape),
+    )
+    if n_chunks < 2:
+        pytest.skip("tiny fixture did not produce multiple chunks")
+
+    energy_full, scales_full, _extra_full = compute_exact_parity_energy_chunked(image, config_full)
+    energy_chunked, scales_chunked, _extra_chunked = compute_exact_parity_energy_chunked(
+        image, config_chunked
+    )
+    del _extra_full, _extra_chunked
+    finite = np.isfinite(energy_full) & np.isfinite(energy_chunked)
+    n_total = int(energy_full.size)
+    n_bit = int(np.count_nonzero(energy_full == energy_chunked))
+    n_scale = int(np.count_nonzero(scales_full != scales_chunked))
+    if n_bit == n_total and n_scale == 0:
+        return
+    abs_delta = (
+        np.abs(energy_full[finite] - energy_chunked[finite]) if np.any(finite) else np.array([])
+    )
+    max_abs = float(np.max(abs_delta)) if abs_delta.size else float("nan")
+    pytest.fail(
+        "E13 chunk-vs-full named a residual: "
+        f"bit-identical {n_bit}/{n_total}, scale mismatches {n_scale}, "
+        f"max abs delta {max_abs}"
+    )

--- a/tests/unit/pipeline/energy/test_stretch_whole_crop_get_energy_policy.py
+++ b/tests/unit/pipeline/energy/test_stretch_whole_crop_get_energy_policy.py
@@ -1,0 +1,33 @@
+"""E14 policy: whole-crop get_energy_V202 must not overwrite protected roots."""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+
+import pytest
+
+from slavv_python.pipeline.energy.matlab_engine_backend import (
+    MatlabEnginePolicyError,
+    refuse_matlab_only_energy_checkpoint_as_stretch_success,
+    refuse_protected_stretch_energy_dest,
+)
+
+
+@pytest.mark.parametrize(
+    "dest_name",
+    ["canonical_full_v18", "crop_M_exact_v3", "crop_M_stretch_engine_v2"],
+)
+def test_e14_refuses_protected_dest_roots(tmp_path: Path, dest_name: str) -> None:
+    dest = tmp_path / "workspace" / "runs" / "oracle_180709_E" / dest_name
+    with pytest.raises(MatlabEnginePolicyError, match="protected root"):
+        refuse_protected_stretch_energy_dest(dest)
+
+
+def test_e14_allows_scratch_dest(tmp_path: Path) -> None:
+    dest = tmp_path / "workspace" / "scratch" / "e14_whole_crop_get_energy_v202"
+    refuse_protected_stretch_energy_dest(dest)
+
+
+def test_e14_matlab_only_checkpoint_is_not_stretch_success() -> None:
+    with pytest.raises(MatlabEnginePolicyError, match="R6"):
+        refuse_matlab_only_energy_checkpoint_as_stretch_success()

--- a/tests/unit/pipeline/energy/test_stretch_worker_marshalling.py
+++ b/tests/unit/pipeline/energy/test_stretch_worker_marshalling.py
@@ -1,0 +1,51 @@
+"""E12: py37 worker ``matlab.double`` list-marshalling bit-identity."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def _e12_payload() -> np.ndarray:
+    rng = np.random.default_rng(12)
+    arr = np.asfortranarray(rng.standard_normal((5, 4, 3), dtype=np.float64))
+    arr[0, 0, 0] = np.inf
+    arr[1, 0, 0] = -np.inf
+    arr[2, 0, 0] = np.nan
+    arr[0, 1, 0] = -0.0
+    return arr
+
+
+def _assert_payload_identity(original: np.ndarray, restored: np.ndarray) -> None:
+    assert restored.shape == original.shape
+    assert restored.dtype == np.float64
+    finite = np.isfinite(original) & np.isfinite(restored)
+    assert int(np.count_nonzero(finite)) >= 1
+    assert np.array_equal(original[finite], restored[finite])
+    assert np.array_equal(np.isnan(original), np.isnan(restored))
+    assert np.array_equal(np.isposinf(original), np.isposinf(restored))
+    assert np.array_equal(np.isneginf(original), np.isneginf(restored))
+
+
+def _worker_float_list_roundtrip(array: np.ndarray) -> np.ndarray:
+    """Python-side npy → Fortran ravel → float list → reshape (no matlab.double)."""
+    arr = np.asfortranarray(np.asarray(array, dtype=np.float64))
+    flat = [float(v) for v in np.ravel(arr, order="F")]
+    return np.reshape(np.asarray(flat, dtype=np.float64), arr.shape, order="F")
+
+
+def test_e12_fortran_float_list_roundtrip_without_engine() -> None:
+    original = _e12_payload()
+    restored = _worker_float_list_roundtrip(original)
+    _assert_payload_identity(original, restored)
+
+
+def test_e12_worker_matlab_double_roundtrip_bit_identical(stretch_py37_worker) -> None:
+    original = _e12_payload()
+    restored = stretch_py37_worker.roundtrip_float64(original)
+    _assert_payload_identity(original, restored)
+    finite = np.isfinite(original)
+    n_finite = int(np.count_nonzero(finite))
+    n_bit_identical = int(np.count_nonzero(original[finite] == restored[finite]))
+    assert n_bit_identical == n_finite, (
+        f"E12 finite bit-identity {n_bit_identical}/{n_finite} (marshalling is not bit-identical)"
+    )


### PR DESCRIPTION
## Summary
- Close E11–E20 as `blocked_float_path`: crop Energy v2 `--strict-floats` is 90.3% bit-identical, not an unlock. Allclose is not stretch success. Phase 1 on `canonical_full_v18` stays CLOSED.
- Land isolation fixtures (E12 marshalling PASS; E13 named sources bit-matched; E14 whole-crop `get_energy_V202` deferred as octave-chunked). Wire `(512,64,512)` orientation refuse into Energy compare before ULP.
- Refresh stretch session docs / HANDOFF (do not relaunch v2). Parked next isolation is one production-sized chunk, not another writer.

## Test plan
- [x] `ruff format` / `ruff check` on touched Python
- [x] `pytest tests/unit/parity/test_stretch_full_volume_gate.py tests/unit/pipeline/energy/test_stretch_whole_crop_get_energy_policy.py tests/unit/pipeline/energy/test_stretch_worker_marshalling.py tests/unit/pipeline/energy/test_stretch_ulp_isolation.py tests/unit/parity/test_mkl_spike_does_not_replace_engine.py` (engine tests skip without py37+R2019a)
- [ ] Confirm ONE TRUTH Phase 1 CLOSED language unchanged
- [ ] Do not relaunch `crop_M_stretch_engine_v2` or overwrite `canonical_full_v18` / `crop_M_exact_v3`

## Summary by Sourcery

Harden MATLAB engine-based Energy stretch parity by isolating float discrepancies, improving worker marshalling/orientation handling, and documenting that crop Energy remains blocked at strict-float parity without relaunching writers.

New Features:
- Add MATLAB engine host APIs and worker operations for float64 roundtrip, linspace mesh generation, interp3 probing, and whole-crop get_energy_V202 timing to support stretch Energy isolation experiments.
- Introduce an orientation gate for Energy comparisons that classifies mismatched shapes (e.g. 512x64x512 vs 64x512x512) as infrastructure refusals before ULP-based float analysis.
- Add policy and helpers to prevent stretch writers and E14 experiments from overwriting protected Energy destinations such as canonical_full_v18, crop_M_exact_v3, and crop_M_stretch_engine_v2.

Enhancements:
- Improve MATLAB engine worker stdout handling by skipping non-JSON noise and logging it, making worker failures more diagnosable.
- Refactor MATLAB worker marshalling into shared helpers and centralize conversion between NumPy arrays and matlab.double / MATLAB float buffers for reliability.
- Extend Energy artifact comparator to consult orientation classification before running the float gate, returning structured failure metadata when orientation issues are detected.

Documentation:
- Update stretch parity handoff, findings, TODO, and plans documentation to record crop Energy strict-float status as blocked_float_path, describe E11–E20 experiment portfolio, and caution operators not to relaunch v2 or overwrite canonical artifacts.
- Add a detailed plan and solution document for crop Energy stretch float isolation, including experiment mapping, status taxonomy, and operator runbooks for future investigations.

Tests:
- Add engine-backed unit tests for worker marshalling, linspace mesh parity, Inf/NaN interp3 behavior, and tiny chunk-vs-full Energy body comparisons to isolate remaining ULP sources.
- Add tests ensuring Energy comparison refuses orientation-mismatched shapes before ULP analysis and that full-volume stretch gating enforces crop unlocks.
- Add policy tests to assert protected Energy destinations are never overwritten and that MATLAB-only Energy checkpoints cannot be treated as stretch success.